### PR TITLE
fix: プロジェクトが未選択の場合にプロジェクトが青字になっていたのを修正

### DIFF
--- a/packages/frontend/src/App.vue
+++ b/packages/frontend/src/App.vue
@@ -36,7 +36,7 @@
               <span>{{ t('nav.projectList') }}</span>
             </el-menu-item>
             <el-menu-item
-              :index="currentProject ? `/projects/${currentProject.id}` : '/projects'"
+              :index="currentProject ? `/projects/${currentProject.id}` : ''"
               :disabled="!currentProject"
             >
               <el-icon><Folder /></el-icon>


### PR DESCRIPTION
# 概要

プロジェクトが未選択の場合にサイドメニューのプロジェクトが青字になっていたのを修正します