### PR TITLE
chore: remove arm64 platform from PR build test to speed up CI

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           context: .
           file: ./allinone/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: false
           build-args: |
             APP_VERSION=dev-test
@@ -45,7 +45,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: false
           build-args: |
             APP_VERSION=dev-test


### PR DESCRIPTION
## Summary

Remove ARM64 platform from PR build test to speed up CI.

- Build test now runs only on `linux/amd64` instead of `linux/amd64,linux/arm64`
- Release builds still include both platforms