### PR TITLE
docs: add issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+<!-- A clear and concise description of what the bug is -->
+
+
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+<!-- What you expected to happen -->
+
+
+
+## Actual Behavior
+<!-- What actually happened -->
+
+
+
+## Environment
+
+- OS:
+- Node.js version:
+- Browser:
+- WireMock Hub version:
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your problem -->
+
+
+
+## Additional Context
+<!-- Add any other context about the problem here -->
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+<!-- A clear and concise description of the feature you'd like -->
+
+
+
+## Use Case
+<!-- Describe the problem or use case this feature would address -->
+
+
+
+## Proposed Solution
+<!-- Describe how you'd like this feature to work -->
+
+
+
+## Alternatives Considered
+<!-- Any alternative solutions or features you've considered -->
+
+
+
+## Additional Context
+<!-- Add any other context or screenshots about the feature request here -->
+
+


### PR DESCRIPTION
## Summary

Add issue templates for bug reports and feature requests.

## Reason for Change

There are no issue templates in this repository. When creating an issue, contributors need to manually structure their reports without guidance, which can lead to inconsistent formats and missing important information.

## Changes

- Add `.github/ISSUE_TEMPLATE/bug_report.md` with sections for description, steps to reproduce, expected/actual behavior, environment, and screenshots
- Add `.github/ISSUE_TEMPLATE/feature_request.md` with sections for summary, use case, proposed solution, alternatives considered, and additional context
