### PR TITLE
fix: consolidate Dependabot npm config for pnpm workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,12 @@
 version: 2
 updates:
-  # Root package.json
+  # All npm packages (pnpm workspace - single lockfile at root)
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     groups:
-      dev-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-
-  # Frontend
-  - package-ecosystem: "npm"
-    directory: "/packages/frontend"
-    schedule:
-      interval: "weekly"
-    groups:
+      # Frontend packages
       vue-ecosystem:
         patterns:
           - "vue*"
@@ -30,18 +18,7 @@ updates:
         patterns:
           - "element-plus"
           - "@element-plus/*"
-      dev-dependencies:
-        dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
-
-  # Backend
-  - package-ecosystem: "npm"
-    directory: "/packages/backend"
-    schedule:
-      interval: "weekly"
-    groups:
+      # Backend packages
       fastify:
         patterns:
           - "fastify"
@@ -50,27 +27,17 @@ updates:
         patterns:
           - "prisma"
           - "@prisma/*"
-      dev-dependencies:
-        dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
-
-  # Shared
-  - package-ecosystem: "npm"
-    directory: "/packages/shared"
-    schedule:
-      interval: "weekly"
-
-  # E2E tests
-  - package-ecosystem: "npm"
-    directory: "/e2e"
-    schedule:
-      interval: "weekly"
-    groups:
+      # E2E packages
       playwright:
         patterns:
           - "@playwright/*"
+      # All other minor/patch updates
+      minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
<!-- Delete any sections that are not applicable to your PR -->

## Summary
<!-- Brief description of the changes -->

pnpm workspace has a single lockfile at root (pnpm-lock.yaml). When Dependabot was configured with separate entries for each subdirectory (/packages/frontend, /packages/backend, etc.), updating package.json in subdirectories did not properly update the root lockfile, causing CI failures with frozen-lockfile.

This change consolidates all npm ecosystem updates into a single root directory entry, which correctly handles pnpm workspace monorepo structure.

## Reason for Change
<!-- Why is this change needed? What problem does it solve? -->
<!-- If this PR resolves an issue, link it: Fixes #123 -->

Dependabot PRs were failing CI with `ERR_PNPM_OUTDATED_LOCKFILE` because pnpm-lock.yaml was not being updated when subdirectory package.json files were modified.

## Changes

### Other
<!-- Database migrations, Docker, CI/CD, etc. -->

- Merged 5 separate npm ecosystem entries into 1 root entry
- Preserved all package groups (vue-ecosystem, element-plus, fastify, prisma, playwright)
- Added `minor-patch` catch-all group for remaining packages
