### PR TITLE
fix: use English examples for scenario placeholder in Japanese locale

### DIFF
--- a/packages/frontend/src/i18n/locales/ja.json
+++ b/packages/frontend/src/i18n/locales/ja.json
@@ -115,9 +115,9 @@
     "persistent": "永続化",
     "placeholder": {
       "url": "例: /api/users",
-      "scenario": "例: ログインフロー",
-      "requiredState": "例: 開始",
-      "newState": "例: ログイン済み"
+      "scenario": "例: login-flow",
+      "requiredState": "例: Started",
+      "newState": "例: LoggedIn"
     }
   },
   "requests": {


### PR DESCRIPTION
## Summary

- Update Japanese locale placeholder examples for WireMock scenario state fields to use English values instead of Japanese translations

## Reason for Change

WireMock's scenario state machine requires exact string matching, and the initial state is always the hardcoded English string "Started". Japanese placeholder examples (e.g., `例: 開始`) were misleading users to enter values that would not work correctly with WireMock.

## Changes

### Frontend

- Updated `packages/frontend/src/i18n/locales/ja.json` to use English examples for scenario-related placeholders while keeping the `例:` prefix

## Modified Files

| File | Changes |
|------|---------|
| `packages/frontend/src/i18n/locales/ja.json` | Changed placeholder examples: `scenario` → `例: login-flow`, `requiredState` → `例: Started`, `newState` → `例: LoggedIn` |

## Test Results

- pnpm test:e2e - 22/22 passed