### PR TITLE
fix: remove duplicate toast notifications from mapping store

### DIFF
--- a/packages/frontend/src/stores/mapping.ts
+++ b/packages/frontend/src/stores/mapping.ts
@@ -55,11 +55,9 @@ export const useMappingStore = defineStore('mapping', () => {
       const created = await stubApi.create(input)
       stubs.value.push(created)
       mappings.value.push({ ...mapping, id: created.id })
-      ElMessage.success(t('messages.stub.created'))
       return created
     } catch (e: any) {
       error.value = e.message || t('messages.stub.createFailed')
-      ElMessage.error(error.value!)
       throw e
     } finally {
       loading.value = false
@@ -80,11 +78,9 @@ export const useMappingStore = defineStore('mapping', () => {
         stubs.value[index] = updated
         mappings.value[index] = { ...mapping, id: updated.id }
       }
-      ElMessage.success(t('messages.stub.updated'))
       return updated
     } catch (e: any) {
       error.value = e.message || t('messages.stub.updateFailed')
-      ElMessage.error(error.value!)
       throw e
     } finally {
       loading.value = false


### PR DESCRIPTION
## Summary

Remove duplicate toast notifications that appear when creating or updating stubs by consolidating notification logic in the view layer.

## Reason for Change

When creating or updating a stub, two success toast notifications appeared simultaneously because both the Pinia store (`mapping.ts`) and the view component (`MappingEditorView.vue`) were independently calling `ElMessage.success()` for the same operation. The same duplication existed for error notifications.

## Changes

### Frontend

- Removed `ElMessage.success()` and `ElMessage.error()` calls from `createMapping()` and `updateMapping()` methods in the mapping store
- Toast notifications are now handled solely by `MappingEditorView.vue`, following the principle that UI concerns belong in the view layer

## Modified Files

| File | Changes |
|------|---------|
| `packages/frontend/src/stores/mapping.ts` | Removed duplicate toast notifications from `createMapping()` and `updateMapping()` methods |

## Test Results

- `pnpm run build` - passed
- `pnpm test` - 6/6 passed