### PR TITLE
ci: add E2E test workflow for pull requests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,76 @@
+name: E2E Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+env:
+  COMPOSE_FILE: docker-compose.yml:docker-compose.demo.yml
+
+jobs:
+  e2e-test:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @wiremock-hub/e2e exec playwright install --with-deps chromium
+
+      - name: Build and start Docker containers
+        run: |
+          docker compose build
+          docker compose up -d
+
+      - name: Wait for services to be ready
+        run: |
+          echo "Waiting for WireMock Hub..."
+          timeout 120 bash -c 'until curl -sf http://localhost:3000/api/projects > /dev/null 2>&1; do sleep 2; done'
+          echo "WireMock Hub is ready!"
+
+          echo "Waiting for WireMock instances..."
+          timeout 60 bash -c 'until curl -sf http://localhost:8081/__admin > /dev/null 2>&1; do sleep 2; done'
+          timeout 60 bash -c 'until curl -sf http://localhost:8082/__admin > /dev/null 2>&1; do sleep 2; done'
+          echo "All WireMock instances are ready!"
+
+      - name: Run E2E tests
+        run: pnpm test:e2e
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 30
+
+      - name: Upload test screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: test-screenshots
+          path: e2e/test-results/
+          retention-days: 7
+
+      - name: Dump Docker logs on failure
+        if: failure()
+        run: docker compose logs --tail=100
+
+      - name: Stop Docker containers
+        if: always()
+        run: docker compose down -v


### PR DESCRIPTION
<!-- Delete any sections that are not applicable to your PR -->

## Summary
<!-- Brief description of the changes -->

Add GitHub Actions workflow to run Playwright E2E tests automatically on pull requests to main branch. The workflow builds Docker containers, waits for services to be ready, runs tests, and uploads artifacts.

Key features:
- Uses COMPOSE_FILE env var to avoid repeating docker-compose files
- Uploads Playwright report (always) and screenshots (on failure)
- Dumps Docker logs on failure for debugging
- Ensures cleanup with `if: always()` on container shutdown


## Reason for Change
<!-- Why is this change needed? What problem does it solve? -->
<!-- If this PR resolves an issue, link it: Fixes #123 -->

Enable automated E2E testing in CI to catch regressions before merging PRs.


## Changes

### Other
<!-- Database migrations, Docker, CI/CD, etc. -->

- Add `.github/workflows/e2e-test.yml` - GitHub Actions workflow for E2E tests


## Checklist

- [x] Tests have been added/updated as needed
- [ ] Documentation has been updated (CLAUDE.md, README.md, etc.)
- [ ] i18n: Both `en.json` and `ja.json` updated (if UI text changed)

## Test Results
<!-- What tests did you run? Did they pass? -->
<!-- e.g., "pnpm test - all passed", "pnpm test:e2e - 18/18 passed" -->

Will be validated when this PR triggers the new workflow.