### PR TITLE
docs: add badges and WireMock link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # WireMock Hub
 
-A GUI client for centralized management of distributed WireMock environments.
+[![Release](https://img.shields.io/github/v/release/ykagano/wiremock-hub?color=blue)](https://github.com/ykagano/wiremock-hub/releases)
+[![Main](https://github.com/ykagano/wiremock-hub/actions/workflows/docker-publish.yml/badge.svg?branch=main)](https://github.com/ykagano/wiremock-hub/actions/workflows/docker-publish.yml)
+[![Docker Pulls](https://img.shields.io/docker/pulls/yukagano/wiremock-hub)](https://hub.docker.com/r/yukagano/wiremock-hub)
+
+Extends [WireMock](https://wiremock.org/) with a graphical user interface for centralized management of distributed WireMock environments.
 
 ## Features
 


### PR DESCRIPTION
## Summary

- Add Release badge (GitHub releases)
- Add Main branch CI/CD status badge
- Add Docker Pulls badge
- Link to WireMock official site (https://wiremock.org/)
- Improve description to clarify project purpose

## Reason for Change

Improve README.md to provide better project visibility and context:
- Badges help users quickly understand the project status (latest version, CI/CD health, popularity)
- Linking to the official WireMock site clarifies that this project extends WireMock
- Updated description makes it clearer that this is a GUI extension for WireMock

## Changes

### Other

- Added three badges to README.md:
  - Release badge showing latest GitHub release version (blue color)
  - Main branch CI/CD workflow status badge
  - Docker Hub pull count badge
- Updated project description from "A GUI client for..." to "Extends WireMock with a graphical user interface for..."
- Added hyperlink to WireMock official site (https://wiremock.org/)
