### PR TITLE
fix: WireMock admin API POST requests send wrong Content-Type

### DIFF
--- a/packages/backend/src/routes/wiremock-instances.ts
+++ b/packages/backend/src/routes/wiremock-instances.ts
@@ -623,7 +623,7 @@ export async function wiremockInstanceRoutes(fastify: FastifyInstance) {
       }
 
       try {
-        const response = await axios.post(`${instance.url}/__admin/recordings/stop`, null, {
+        const response = await axios.post(`${instance.url}/__admin/recordings/stop`, {}, {
           timeout: 10000
         });
 
@@ -717,7 +717,7 @@ export async function wiremockInstanceRoutes(fastify: FastifyInstance) {
 
       const results = await Promise.allSettled(
         instances.map(async (instance) => {
-          await axios.post(`${instance.url}/__admin/recordings/stop`, null, {
+          await axios.post(`${instance.url}/__admin/recordings/stop`, {}, {
             timeout: 10000
           });
           return instance.name;
@@ -810,7 +810,7 @@ export async function wiremockInstanceRoutes(fastify: FastifyInstance) {
       }
 
       try {
-        await axios.post(`${instance.url}/__admin/scenarios/reset`, null, {
+        await axios.post(`${instance.url}/__admin/scenarios/reset`, {}, {
           timeout: 10000
         });
 

--- a/packages/backend/src/routes/wiremock-instances.ts
+++ b/packages/backend/src/routes/wiremock-instances.ts
@@ -623,9 +623,13 @@ export async function wiremockInstanceRoutes(fastify: FastifyInstance) {
       }
 
       try {
-        const response = await axios.post(`${instance.url}/__admin/recordings/stop`, {}, {
-          timeout: 10000
-        });
+        const response = await axios.post(
+          `${instance.url}/__admin/recordings/stop`,
+          {},
+          {
+            timeout: 10000
+          }
+        );
 
         return reply.send({
           success: true,
@@ -717,9 +721,13 @@ export async function wiremockInstanceRoutes(fastify: FastifyInstance) {
 
       const results = await Promise.allSettled(
         instances.map(async (instance) => {
-          await axios.post(`${instance.url}/__admin/recordings/stop`, {}, {
-            timeout: 10000
-          });
+          await axios.post(
+            `${instance.url}/__admin/recordings/stop`,
+            {},
+            {
+              timeout: 10000
+            }
+          );
           return instance.name;
         })
       );
@@ -810,9 +818,13 @@ export async function wiremockInstanceRoutes(fastify: FastifyInstance) {
       }
 
       try {
-        await axios.post(`${instance.url}/__admin/scenarios/reset`, {}, {
-          timeout: 10000
-        });
+        await axios.post(
+          `${instance.url}/__admin/scenarios/reset`,
+          {},
+          {
+            timeout: 10000
+          }
+        );
 
         return reply.send({
           success: true,


### PR DESCRIPTION
## Summary

- Fix `Stop Recording` and `Reset Scenarios` failing with 400 error from WireMock

## Reason for Change

`axios.post(url, null, config)` in axios 1.14.0 sends `Content-Type: application/x-www-form-urlencoded` instead of `application/json`. WireMock's admin API expects JSON content type, causing it to return HTTP 400 even though the operation is actually processed internally. This results in a confusing "Failed to stop recording" error in the UI despite the recording being successfully stopped.

## Changes

### Backend

- Changed `null` to `{}` in 3 `axios.post()` calls to WireMock admin API so that axios sends `Content-Type: application/json`

## Modified Files

| File | Changes |
|------|---------|
| `packages/backend/src/routes/wiremock-instances.ts` | L626: recording/stop (individual), L720: recording/stop-all, L813: scenarios/reset — changed `null` to `{}` |

## Test Results

- `pnpm --filter @wiremock-hub/backend test` — 203/203 passed
- `pnpm run lint` — passed