### PR TITLE
chore: generate release notes with Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -14,6 +14,8 @@ categories:
   - title: '🧪 Tests'
     labels:
       - 'test'
+  - title: '🔧 Other Changes'
+    labels: []
   - title: '⬆️ Dependencies'
     labels:
       - 'dependencies'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,28 @@
+name-template: 'Release v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features & Improvements'
+    labels:
+      - 'enhancement'
+      - 'improvement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+  - title: '📝 Documentation'
+    labels:
+      - 'documentation'
+  - title: '🧪 Tests'
+    labels:
+      - 'test'
+  - title: '⬆️ Dependencies'
+    labels:
+      - 'dependencies'
+    collapse-after: 3
+change-template: '- $TITLE by @$AUTHOR in #$NUMBER'
+change-title-escapes: '\<*_&#@'
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPO/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,6 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
 
     steps:
       - name: Checkout
@@ -81,12 +82,16 @@ jobs:
 
       - name: Create Release
         if: steps.check-release.outputs.exists == 'false'
+        uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1
+        with:
+          config-name: release-drafter.yml
+          tag: ${{ needs.prepare.outputs.tag_name }}
+          name: Release ${{ needs.prepare.outputs.tag_name }}
+          version: ${{ needs.prepare.outputs.version }}
+          commitish: ${{ needs.prepare.outputs.tag_name }}
+          publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create ${{ needs.prepare.outputs.tag_name }} \
-            --generate-notes \
-            --title "Release ${{ needs.prepare.outputs.tag_name }}"
 
   build-allinone-platform:
     needs: [prepare, create-release]


### PR DESCRIPTION
## Summary

Generate the "What's Changed" release notes with Release Drafter so that dependabot dependency-update PRs are grouped and collapsed into a `<details>` block instead of being listed flat. PRs are also categorized using the repository's existing labels, and any uncategorized PR is gathered under a catch-all section.

## Reason for Change

The current flow generates notes via `gh release create --generate-notes`, which lists every PR title flat. Dependency bumps dominate the changelog (e.g. v0.17.5 was just 6 dependabot bumps in a row). Release Drafter categorizes PRs by their existing labels and collapses dependency updates, making each release much easier to read.

## Changes

### Other (CI/CD)

- Add `.github/release-drafter.yml`:
  - Categorizes PRs by existing labels (`enhancement`/`improvement`, `bug`, `documentation`, `test`).
  - Collapses the `dependencies` category (all dependabot PRs) into a `<details>` block via `collapse-after: 3`.
  - Adds a `🔧 Other Changes` catch-all category (`labels: []`) so uncategorized or unlabeled PRs get a section header instead of floating headerless at the top. Dependabot PRs always carry `dependencies`, so they never fall into this bucket.
- Update `.github/workflows/docker-publish.yml` `create-release` job: replace `gh release create --generate-notes` with `release-drafter/release-drafter@v7.3.1` (SHA-pinned, `publish: true`), passing explicit `tag`/`name`/`version`/`commitish`. Add `pull-requests: read` permission. The tag-driven flow and the "skip if release already exists" idempotency guard are preserved.

No autolabeler workflow is added: the repository already labels PRs manually and dependabot auto-applies the `dependencies` label, so label-based categorization works as-is.

## Modified Files

| File | Changes |
|------|---------|
| `.github/release-drafter.yml` | New. Release Drafter config: label-based categories, a catch-all `Other Changes` category, and `collapse-after` for dependencies. |
| `.github/workflows/docker-publish.yml` | Swap `--generate-notes` for the Release Drafter action; add `pull-requests: read`. |

## Test Results

- YAML syntax check (python `yaml`): passed (verified exactly one empty-labels catch-all category, placed before Dependencies)
- `actionlint`: no new findings on the added step (only pre-existing info/style shellcheck notes in untouched run blocks)
- `pnpm run format:check`: All matched files use Prettier code style
- The release workflow itself runs only on tag push; config and action inputs were validated statically against the v7.3.1 schema and source (`tag`/`name`/`version`/`commitish`/`publish` inputs and `categories`/`collapse-after` config confirmed)