### PR TITLE
fix(ci): use default branch as release commitish instead of tag name

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -88,7 +88,7 @@ jobs:
           tag: ${{ needs.prepare.outputs.tag_name }}
           name: Release ${{ needs.prepare.outputs.tag_name }}
           version: ${{ needs.prepare.outputs.version }}
-          commitish: ${{ needs.prepare.outputs.tag_name }}
+          commitish: ${{ github.event.repository.default_branch }}
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes the `Create Release` step in the Docker release workflow (`docker-publish.yml`), which was failing and preventing the v0.17.6 release and image publish from completing.

## Root cause

`commitish` was set to the tag name (e.g. `v0.17.6`). release-drafter forwards this value to GitHub's create-release API as `target_commitish`, but `target_commitish` only accepts a **branch name or commit SHA** — passing a tag ref is rejected:

```
Validation Failed: {"resource":"Release","code":"invalid","field":"target_commitish"}
```

This caused `create-release` to fail, which in turn skipped all downstream Build / Manifest jobs ([failed run](https://github.com/ykagano/wiremock-hub/actions/runs/26993588337/job/79658677776)).

This is a regression introduced in `3255b2b`, when the release step was switched from `gh release create` to release-drafter. The old `gh release create` attaches directly to the existing tag and never sends `target_commitish`, so it was unaffected.

## Fix

Point `commitish` at the default branch. The `prepare` job already creates and pushes the tag, so the release only needs to attach to that existing tag — the default branch is a valid commitish and avoids GitHub re-validating a tag ref as a commit.

```diff
-          commitish: ${{ needs.prepare.outputs.tag_name }}
+          commitish: ${{ github.event.repository.default_branch }}
```

## Impact

- `github.event.repository.default_branch` resolves correctly for both the `push: tags` and `workflow_dispatch` triggers.
- Behavior change is limited to release creation; build and publish logic is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)