### PR TITLE
fix: correct release-drafter changelog variable from $REPO to $REPOSITORY

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -27,4 +27,4 @@ template: |
 
   $CHANGES
 
-  **Full Changelog**: https://github.com/$OWNER/$REPO/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION


### PR DESCRIPTION
## Summary

Fixes the **Full Changelog** link in the release notes template, which rendered a literal `$REPO` instead of the repository name.

## Reason for Change

`release-drafter` has no `$REPO` template variable, so the link was generated as:

```
Full Changelog: https://github.com/ykagano/$REPO/compare/v0.17.5...v0.17.6
```

`$OWNER` resolved correctly, but `$REPO` was left untouched because it is not a supported variable. The correct variable for the repository name is `$REPOSITORY`.

## Changes

### Other

- `.github/release-drafter.yml`: change the changelog URL variable from `$REPO` to `$REPOSITORY`.

## Modified Files

| File | Changes |
|------|---------|
| `.github/release-drafter.yml` | Use `$REPOSITORY` instead of the non-existent `$REPO` in the Full Changelog link |

## Test Results

Config-only one-line change; no code paths affected. The corrected variable will produce `https://github.com/ykagano/wiremock-hub/compare/...` on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)