### PR TITLE
feat: bulk delete stubs via row selection on Stub Mappings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,6 +371,7 @@ packages/
 - `PUT /api/stubs/:id` - Update stub
 - `DELETE /api/stubs/:id` - Delete stub
 - `DELETE /api/stubs?projectId=` - Delete all stubs in project (bulk delete)
+- `POST /api/stubs/bulk-delete` - Delete selected stubs by IDs (`{ projectId, ids }`)
 - `POST /api/stubs/:id/sync` - Sync to WireMock
 - `POST /api/stubs/:id/test` - Test stub against all WireMock instances
 - `POST /api/stubs/sync-all` - Sync all stubs to WireMock (reset then register)

--- a/e2e/tests/stub.spec.ts
+++ b/e2e/tests/stub.spec.ts
@@ -900,6 +900,80 @@ test.describe('Stub', () => {
     await cleanupProject(page, testProjectName);
   });
 
+  test('should bulk delete selected stubs', async ({ page }) => {
+    const testProjectName = `Stub Bulk Delete Test ${Date.now()}`;
+
+    // Create project
+    await page
+      .locator('.page-header')
+      .getByRole('button', { name: /プロジェクト追加|Add Project/ })
+      .click();
+    await page.getByLabel(/プロジェクト名|Name/).fill(testProjectName);
+    await page
+      .locator('.el-dialog')
+      .getByRole('button', { name: /保存|Save/ })
+      .click();
+
+    // Go to project detail
+    const projectCard = page.locator('.el-card', { hasText: testProjectName });
+    await projectCard.getByRole('button', { name: /詳細|Detail/ }).click();
+    await page.waitForTimeout(1000);
+
+    // Navigate to stubs tab
+    await page.getByRole('menuitem', { name: /スタブマッピング|Stub Mappings/ }).click();
+    await page.waitForTimeout(500);
+
+    // Create three stubs
+    for (const path of ['/api/bulk-1', '/api/bulk-2', '/api/bulk-3']) {
+      await page
+        .getByRole('button', { name: /新規作成|Create New/ })
+        .first()
+        .click();
+      await page.getByRole('tab', { name: /リクエスト|Request/ }).click();
+      await page.getByPlaceholder('e.g. /api/users').fill(path);
+      await page.getByRole('button', { name: /保存|Save/ }).click();
+      await expect(page.locator('.el-table__row', { hasText: path })).toBeVisible({
+        timeout: 10000
+      });
+    }
+
+    await expect(page.locator('.el-table__row')).toHaveCount(3);
+
+    // Select the first two rows via their checkboxes (selection column)
+    const row1 = page.locator('.el-table__row', { hasText: '/api/bulk-1' });
+    const row2 = page.locator('.el-table__row', { hasText: '/api/bulk-2' });
+    await row1.locator('.el-checkbox__inner').click();
+    await row2.locator('.el-checkbox__inner').click();
+
+    // The header switches to the selection action bar
+    const selectionHeader = page.locator('.selection-header');
+    await expect(selectionHeader).toBeVisible();
+    await expect(selectionHeader).toContainText(/2件選択中|2 selected/);
+
+    // Click "Delete Selected"
+    await selectionHeader.getByRole('button', { name: /選択を削除|Delete Selected/ }).click();
+
+    // Confirm deletion
+    await page
+      .locator('.el-message-box')
+      .getByRole('button', { name: /はい|Yes|確認/ })
+      .click();
+    await expect(page.locator('.el-message-box')).not.toBeVisible();
+    await page.waitForTimeout(500);
+
+    // The two selected stubs are gone, the third remains
+    await expect(page.locator('.el-table__row', { hasText: '/api/bulk-1' })).not.toBeVisible();
+    await expect(page.locator('.el-table__row', { hasText: '/api/bulk-2' })).not.toBeVisible();
+    await expect(page.locator('.el-table__row', { hasText: '/api/bulk-3' })).toBeVisible();
+    await expect(page.locator('.el-table__row')).toHaveCount(1);
+
+    // The selection bar disappears once the selection is cleared
+    await expect(page.locator('.selection-header')).not.toBeVisible();
+
+    // Clean up
+    await cleanupProject(page, testProjectName);
+  });
+
   test('should export and import stubs in unified WireMock-compatible format', async ({ page }) => {
     const testProjectName = `Export Import ${Date.now()}`;
 

--- a/e2e/tests/stub.spec.ts
+++ b/e2e/tests/stub.spec.ts
@@ -974,6 +974,59 @@ test.describe('Stub', () => {
     await cleanupProject(page, testProjectName);
   });
 
+  test('should clear selection when the search filter changes', async ({ page }) => {
+    const testProjectName = `Stub Selection Filter Test ${Date.now()}`;
+
+    // Create project
+    await page
+      .locator('.page-header')
+      .getByRole('button', { name: /プロジェクト追加|Add Project/ })
+      .click();
+    await page.getByLabel(/プロジェクト名|Name/).fill(testProjectName);
+    await page
+      .locator('.el-dialog')
+      .getByRole('button', { name: /保存|Save/ })
+      .click();
+
+    // Go to project detail
+    const projectCard = page.locator('.el-card', { hasText: testProjectName });
+    await projectCard.getByRole('button', { name: /詳細|Detail/ }).click();
+    await page.waitForTimeout(1000);
+
+    // Navigate to stubs tab
+    await page.getByRole('menuitem', { name: /スタブマッピング|Stub Mappings/ }).click();
+    await page.waitForTimeout(500);
+
+    // Create two stubs
+    for (const path of ['/api/filter-1', '/api/filter-2']) {
+      await page
+        .getByRole('button', { name: /新規作成|Create New/ })
+        .first()
+        .click();
+      await page.getByRole('tab', { name: /リクエスト|Request/ }).click();
+      await page.getByPlaceholder('e.g. /api/users').fill(path);
+      await page.getByRole('button', { name: /保存|Save/ }).click();
+      await expect(page.locator('.el-table__row', { hasText: path })).toBeVisible({
+        timeout: 10000
+      });
+    }
+
+    // Select a row -> selection bar appears
+    await page
+      .locator('.el-table__row', { hasText: '/api/filter-1' })
+      .locator('.el-checkbox__inner')
+      .click();
+    await expect(page.locator('.selection-header')).toBeVisible();
+
+    // Changing the search filter clears the selection (so hidden rows are never deleted)
+    await page.getByPlaceholder(/検索|Search/).fill('filter-2');
+    await expect(page.locator('.selection-header')).not.toBeVisible();
+    await expect(page.locator('.el-table__row', { hasText: '/api/filter-1' })).not.toBeVisible();
+
+    // Clean up
+    await cleanupProject(page, testProjectName);
+  });
+
   test('should export and import stubs in unified WireMock-compatible format', async ({ page }) => {
     const testProjectName = `Export Import ${Date.now()}`;
 

--- a/packages/backend/src/routes/stubs.ts
+++ b/packages/backend/src/routes/stubs.ts
@@ -40,6 +40,11 @@ const importOpenApiSchema = z.object({
   format: z.enum(['json', 'yaml']).optional()
 });
 
+const bulkDeleteSchema = z.object({
+  projectId: z.string().uuid(),
+  ids: z.array(z.string().uuid()).min(1)
+});
+
 export async function stubRoutes(fastify: FastifyInstance) {
   // Helper to check project exists
   async function checkProjectExists(projectId: string) {
@@ -230,6 +235,38 @@ export async function stubRoutes(fastify: FastifyInstance) {
       });
     }
   );
+
+  // Bulk delete stubs by IDs
+  fastify.post('/bulk-delete', async (request: FastifyRequest, reply: FastifyReply) => {
+    const parsed = bulkDeleteSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.status(400).send({
+        success: false,
+        error: parsed.error.issues[0]?.message || 'Invalid request body'
+      });
+    }
+
+    const { projectId, ids } = parsed.data;
+
+    const project = await checkProjectExists(projectId);
+    if (!project) {
+      return reply.status(404).send({
+        success: false,
+        error: 'Project not found'
+      });
+    }
+
+    const result = await fastify.prisma.stub.deleteMany({
+      where: { projectId, id: { in: ids } }
+    });
+
+    return reply.send({
+      success: true,
+      data: {
+        deletedCount: result.count
+      }
+    });
+  });
 
   // Delete stub
   fastify.delete(

--- a/packages/backend/tests/routes/stubs.test.ts
+++ b/packages/backend/tests/routes/stubs.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { getTestApp } from '../setup.js';
-import { resetAndCreateProject } from '../helpers.js';
+import { resetAndCreateProject, createProject } from '../helpers.js';
 
 describe('Stubs API - CRUD', () => {
   let projectId: string;
@@ -465,6 +465,128 @@ describe('Stubs API - CRUD', () => {
       const response = await app.inject({
         method: 'DELETE',
         url: '/api/stubs?projectId=00000000-0000-0000-0000-000000000000'
+      });
+
+      expect(response.statusCode).toBe(404);
+      const result = response.json();
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Project not found');
+    });
+  });
+
+  describe('POST /api/stubs/bulk-delete', () => {
+    async function createStub(app: Awaited<ReturnType<typeof getTestApp>>, name: string) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/stubs',
+        payload: {
+          projectId,
+          name,
+          mapping: { request: { url: `/${name}` }, response: { status: 200 } }
+        }
+      });
+      return res.json().data.id as string;
+    }
+
+    it('should delete only the specified stubs', async () => {
+      const app = await getTestApp();
+
+      const id1 = await createStub(app, 'bulk1');
+      const id2 = await createStub(app, 'bulk2');
+      await createStub(app, 'bulk3');
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/stubs/bulk-delete',
+        payload: { projectId, ids: [id1, id2] }
+      });
+
+      expect(response.statusCode).toBe(200);
+      const result = response.json();
+      expect(result.success).toBe(true);
+      expect(result.data.deletedCount).toBe(2);
+
+      // Only the non-selected stub remains
+      const listResponse = await app.inject({
+        method: 'GET',
+        url: `/api/stubs?projectId=${projectId}`
+      });
+      const remaining = listResponse.json().data;
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].name).toBe('bulk3');
+    });
+
+    it('should ignore ids that do not exist', async () => {
+      const app = await getTestApp();
+
+      const id1 = await createStub(app, 'bulk1');
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/stubs/bulk-delete',
+        payload: { projectId, ids: [id1, '00000000-0000-0000-0000-000000000000'] }
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().data.deletedCount).toBe(1);
+    });
+
+    it('should not delete stubs from another project', async () => {
+      const app = await getTestApp();
+
+      const id1 = await createStub(app, 'bulk1');
+      const otherProjectId = await createProject('Other Project');
+      const otherRes = await app.inject({
+        method: 'POST',
+        url: '/api/stubs',
+        payload: {
+          projectId: otherProjectId,
+          name: 'other',
+          mapping: { request: { url: '/other' }, response: { status: 200 } }
+        }
+      });
+      const otherId = otherRes.json().data.id as string;
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/stubs/bulk-delete',
+        payload: { projectId, ids: [id1, otherId] }
+      });
+
+      expect(response.statusCode).toBe(200);
+      // Only the stub belonging to projectId is deleted
+      expect(response.json().data.deletedCount).toBe(1);
+
+      const otherList = await app.inject({
+        method: 'GET',
+        url: `/api/stubs?projectId=${otherProjectId}`
+      });
+      expect(otherList.json().data).toHaveLength(1);
+    });
+
+    it('should return 400 when ids is empty', async () => {
+      const app = await getTestApp();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/stubs/bulk-delete',
+        payload: { projectId, ids: [] }
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json().success).toBe(false);
+    });
+
+    it('should return 404 for non-existent project', async () => {
+      const app = await getTestApp();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/stubs/bulk-delete',
+        payload: {
+          projectId: '00000000-0000-0000-0000-000000000000',
+          ids: ['11111111-1111-4111-8111-111111111111']
+        }
       });
 
       expect(response.statusCode).toBe(404);

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -132,7 +132,11 @@
     "name": "Name",
     "scenario": "Scenario",
     "confirmReset": "Delete all stubs in this project? This action cannot be undone.",
-    "confirmResetNote": "To also delete stubs on WireMock instances, run \"Sync All Instances\" after deletion."
+    "confirmResetNote": "To also delete stubs on WireMock instances, run \"Sync All Instances\" after deletion.",
+    "selectedCount": "{count} selected",
+    "deleteSelected": "Delete Selected",
+    "clearSelection": "Clear Selection",
+    "confirmBulkDelete": "Delete {count} selected stub(s)? This action cannot be undone."
   },
   "editor": {
     "title": "Stub Editor",
@@ -415,6 +419,7 @@
       "updateFailed": "Failed to update stub",
       "deleted": "Stub deleted",
       "deleteFailed": "Failed to delete stub",
+      "bulkDeleted": "Deleted {count} stub(s)",
       "synced": "Synced to WireMock",
       "syncFailed": "Failed to sync to WireMock",
       "syncedCount": "Synced {count} stub(s) to WireMock",

--- a/packages/frontend/src/i18n/locales/ja.json
+++ b/packages/frontend/src/i18n/locales/ja.json
@@ -132,7 +132,11 @@
     "name": "名前",
     "scenario": "シナリオ",
     "confirmReset": "プロジェクト内のすべてのスタブを削除しますか？この操作は取り消せません。",
-    "confirmResetNote": "WireMock側のスタブも削除する場合は、削除後に「全インスタンスに同期」を実行してください。"
+    "confirmResetNote": "WireMock側のスタブも削除する場合は、削除後に「全インスタンスに同期」を実行してください。",
+    "selectedCount": "{count}件選択中",
+    "deleteSelected": "選択を削除",
+    "clearSelection": "選択解除",
+    "confirmBulkDelete": "選択した{count}件のスタブを削除しますか？この操作は取り消せません。"
   },
   "editor": {
     "title": "スタブエディタ",
@@ -415,6 +419,7 @@
       "updateFailed": "スタブの更新に失敗しました",
       "deleted": "スタブを削除しました",
       "deleteFailed": "スタブの削除に失敗しました",
+      "bulkDeleted": "{count}件のスタブを削除しました",
       "synced": "WireMockに同期しました",
       "syncFailed": "WireMockへの同期に失敗しました",
       "syncedCount": "{count}件のスタブをWireMockに同期しました",

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -278,6 +278,17 @@ export const stubApi = {
     return response.data.data;
   },
 
+  async bulkDelete(projectId: string, ids: string[]): Promise<{ deletedCount: number }> {
+    const response = await apiClient.post<ApiResponse<{ deletedCount: number }>>(
+      '/stubs/bulk-delete',
+      { projectId, ids }
+    );
+    if (!response.data.data) {
+      throw new Error('Failed to delete stubs: unexpected response');
+    }
+    return response.data.data;
+  },
+
   async sync(id: string, instanceId: string): Promise<void> {
     await apiClient.post(`/stubs/${id}/sync`, { instanceId });
   },

--- a/packages/frontend/src/stores/mapping.ts
+++ b/packages/frontend/src/stores/mapping.ts
@@ -115,6 +115,32 @@ export const useMappingStore = defineStore('mapping', () => {
     }
   }
 
+  // Bulk delete stubs by IDs
+  async function deleteMappings(ids: string[]): Promise<boolean> {
+    const projectStore = useProjectStore();
+    if (!projectStore.currentProjectId) {
+      ElMessage.warning(t('messages.project.notSelected'));
+      return false;
+    }
+    if (ids.length === 0) return false;
+
+    loading.value = true;
+    try {
+      const result = await stubApi.bulkDelete(projectStore.currentProjectId, ids);
+      const idSet = new Set(ids);
+      stubs.value = stubs.value.filter((s) => !idSet.has(s.id));
+      mappings.value = mappings.value.filter((m) => !m.id || !idSet.has(m.id));
+      ElMessage.success(t('messages.stub.bulkDeleted', { count: result.deletedCount }));
+      return true;
+    } catch (e: any) {
+      error.value = e.message || t('messages.stub.deleteFailed');
+      ElMessage.error(error.value!);
+      throw e;
+    } finally {
+      loading.value = false;
+    }
+  }
+
   // Sync to WireMock
   async function syncToWiremock(stubId: string, instanceId: string): Promise<boolean> {
     loading.value = true;
@@ -347,6 +373,7 @@ export const useMappingStore = defineStore('mapping', () => {
     createMapping,
     updateMapping,
     deleteMapping,
+    deleteMappings,
     syncToWiremock,
     syncAllToWiremock,
     replaceStubs,

--- a/packages/frontend/src/views/MappingsView.vue
+++ b/packages/frontend/src/views/MappingsView.vue
@@ -1,6 +1,24 @@
 <template>
   <div class="mapping-list">
-    <div class="page-header">
+    <!-- Selection action bar (shown when one or more rows are selected) -->
+    <div v-if="hasSelection" class="page-header selection-header">
+      <div class="selection-info">
+        <el-icon><Select /></el-icon>
+        <span>{{ t('mappings.selectedCount', { count: selectedCount }) }}</span>
+      </div>
+      <div class="header-actions">
+        <el-button type="danger" @click="confirmBulkDelete" :loading="loading">
+          <el-icon><Delete /></el-icon>
+          {{ t('mappings.deleteSelected') }}
+        </el-button>
+        <el-button @click="clearSelection">
+          <el-icon><Close /></el-icon>
+          {{ t('mappings.clearSelection') }}
+        </el-button>
+      </div>
+    </div>
+
+    <div v-else class="page-header">
       <h2>{{ t('mappings.title') }}</h2>
       <div class="header-actions">
         <el-button @click="fetchMappings" :loading="loading">
@@ -97,12 +115,17 @@
     <!-- Mapping list table -->
     <el-table
       v-else
+      ref="tableRef"
       :data="paginatedMappings"
+      row-key="id"
       stripe
       style="width: 100%"
       @row-click="handleRowClick"
+      @selection-change="handleSelectionChange"
       class="mapping-table"
     >
+      <el-table-column type="selection" width="48" :reserve-selection="true" />
+
       <el-table-column type="expand">
         <template #default="{ row }">
           <div class="expand-content">
@@ -207,7 +230,7 @@ import { useSyncAllInstances } from '@/composables/useSyncAllInstances';
 import { useResponsive } from '@/composables/useResponsive';
 import { usePageSize } from '@/composables/usePageSize';
 import StubTestDialog from '@/components/mapping/StubTestDialog.vue';
-import { ElMessage, ElMessageBox } from 'element-plus';
+import { ElMessage, ElMessageBox, ElTable } from 'element-plus';
 import type { Mapping, MappingRequest } from '@/types/wiremock';
 import { getMethodTagType, getUrl, getStatusTagType } from '@/utils/wiremock';
 
@@ -225,6 +248,47 @@ const currentPage = ref(1);
 const { pageSize, pageSizes } = usePageSize();
 const testDialogVisible = ref(false);
 const testTargetStubId = ref('');
+
+// Row selection (for bulk delete)
+const tableRef = ref<InstanceType<typeof ElTable> | null>(null);
+const selectedRows = ref<Mapping[]>([]);
+const selectedCount = computed(() => selectedRows.value.length);
+const hasSelection = computed(() => selectedCount.value > 0);
+
+function handleSelectionChange(rows: Mapping[]) {
+  selectedRows.value = rows;
+}
+
+function clearSelection() {
+  tableRef.value?.clearSelection();
+  selectedRows.value = [];
+}
+
+function confirmBulkDelete() {
+  const ids = selectedRows.value.map((r) => r.id).filter((id): id is string => Boolean(id));
+  if (ids.length === 0) return;
+
+  ElMessageBox.confirm(
+    t('mappings.confirmBulkDelete', { count: ids.length }),
+    t('common.confirm'),
+    {
+      confirmButtonText: t('common.yes'),
+      cancelButtonText: t('common.no'),
+      type: 'warning'
+    }
+  )
+    .then(async () => {
+      try {
+        await mappingStore.deleteMappings(ids);
+        clearSelection();
+      } catch (error) {
+        console.error('Failed to bulk delete mappings:', error);
+      }
+    })
+    .catch(() => {
+      // Cancelled
+    });
+}
 
 // Filtering
 const filteredMappings = computed(() => {
@@ -283,7 +347,9 @@ function editMapping(mapping: Mapping) {
   router.push(`/mappings/${mapping.id || mapping.uuid}`);
 }
 
-function handleRowClick(row: Mapping) {
+function handleRowClick(row: Mapping, column?: { type?: string }) {
+  // Don't navigate when the click targets the selection checkbox or expand cell
+  if (column?.type === 'selection' || column?.type === 'expand') return;
   editMapping(row);
 }
 
@@ -466,6 +532,22 @@ onMounted(() => {
   margin: 0;
   font-size: 24px;
   font-weight: 600;
+}
+
+.selection-header {
+  padding: 10px 16px;
+  background-color: var(--el-color-primary-light-9);
+  border: 1px solid var(--el-color-primary-light-7);
+  border-radius: 6px;
+}
+
+.selection-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--el-color-primary);
 }
 
 .header-actions {

--- a/packages/frontend/src/views/MappingsView.vue
+++ b/packages/frontend/src/views/MappingsView.vue
@@ -220,7 +220,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, h } from 'vue';
+import { ref, computed, onMounted, watch, h } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
@@ -289,6 +289,13 @@ function confirmBulkDelete() {
       // Cancelled
     });
 }
+
+// Reset the selection whenever the filter/search context changes, so that
+// "Delete Selected" never targets rows hidden by the current filter.
+// Pagination is intentionally excluded to preserve cross-page selection.
+watch([searchQuery, filterMethod], () => {
+  if (hasSelection.value) clearSelection();
+});
 
 // Filtering
 const filteredMappings = computed(() => {


### PR DESCRIPTION
## Summary

Add a bulk-delete UI to the Stub Mappings screen. A selection checkbox column appears on the left of the table; selecting one or more rows switches the page header into an action bar showing the selected count, **Delete Selected**, and **Clear Selection**.

## Reason for Change

Previously stubs could only be deleted one at a time (per-row trash button) or all at once ("Delete All"). There was no way to delete an arbitrary subset of stubs. This adds selective bulk deletion.

## Changes

### Backend
- Add `POST /api/stubs/bulk-delete` accepting `{ projectId, ids }`. Deletes the matching stubs scoped to the project via `deleteMany` and returns `{ deletedCount }`.

### Frontend
- `MappingsView.vue`: add a selection column (`type="selection"`, `row-key="id"`, `reserve-selection` so selection persists across pages). The page header switches to a selection action bar when rows are selected. Guard `row-click` so selecting/expanding a row does not navigate to the editor. Clear the selection when the search query or method filter changes so rows hidden by the filter are never deleted.
- Add `stubApi.bulkDelete()` and the mapping store `deleteMappings(ids)` action.
- Add i18n keys (ja/en): `selectedCount`, `deleteSelected`, `clearSelection`, `confirmBulkDelete`, `bulkDeleted`.

### Other
- Document the new endpoint in `CLAUDE.md`.

## Modified Files

| File | Changes |
|------|---------|
| `packages/backend/src/routes/stubs.ts` | Add `POST /api/stubs/bulk-delete` endpoint with zod validation |
| `packages/backend/tests/routes/stubs.test.ts` | Tests for bulk-delete (subset / ignore missing ids / project scoping / empty 400 / 404) |
| `packages/frontend/src/services/api.ts` | `stubApi.bulkDelete(projectId, ids)` |
| `packages/frontend/src/stores/mapping.ts` | `deleteMappings(ids)` store action |
| `packages/frontend/src/views/MappingsView.vue` | Selection column, header action bar, row-click guard, filter-change selection reset |
| `packages/frontend/src/i18n/locales/en.json`, `ja.json` | New i18n keys |
| `CLAUDE.md` | Document bulk-delete endpoint |
| `e2e/tests/stub.spec.ts` | E2E: bulk delete selected stubs; selection clears on filter change |

## Test Results

- `pnpm --filter @wiremock-hub/backend test` — 208 passed
- `pnpm test:e2e:keep-data stub.spec.ts` — 16 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
