### PR TITLE
fix: copy shared dist into allinone runtime image

### DIFF
--- a/allinone/Dockerfile
+++ b/allinone/Dockerfile
@@ -108,7 +108,9 @@ RUN corepack enable && corepack install
 RUN pnpm install --frozen-lockfile --prod && \
     apk del python3 make g++
 
-# Copy backend build (includes generated Prisma client in dist/)
+# Copy built files (includes generated Prisma client in dist/)
+# shared/dist is required at runtime because backend imports @wiremock-hub/shared
+COPY --from=backend-builder /app/packages/shared/dist ./packages/shared/dist
 COPY --from=backend-builder /app/packages/backend/dist ./packages/backend/dist
 COPY --from=backend-builder /app/packages/backend/prisma ./packages/backend/prisma
 


### PR DESCRIPTION
## Summary

Fix the All-in-One image failing to start (502 Bad Gateway) by copying `packages/shared/dist` into the runtime stage of `allinone/Dockerfile`.

## Reason for Change

Since f322abb (v0.18.1), `packages/backend/src/routes/stubs.ts` has a runtime import from `@wiremock-hub/shared` (`extractEqualToValues`, `generateSampleBody`). Previously the backend only used `import type` from the shared package, which is erased at compile time, so the runtime image never needed `packages/shared/dist`.

The All-in-One runtime stage copies only `packages/shared/package.json`, so the workspace symlink created by `pnpm install --prod` points to a package whose `dist/` does not exist. The backend crashes on boot with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/packages/backend/node_modules/@wiremock-hub/shared/dist/index.js'
```

supervisord gives up after retries (`FATAL state`), and nginx returns 502 for `/hub/`.

The standalone image already has this COPY line (`Dockerfile:69`) and is not affected.

## Changes

### Other

- Added `COPY --from=backend-builder /app/packages/shared/dist ./packages/shared/dist` to the runtime stage of `allinone/Dockerfile`, matching the standalone Dockerfile.

## Modified Files

| File | Changes |
|------|---------|
| `allinone/Dockerfile` | Copy `packages/shared/dist` into the runtime stage so the backend can resolve `@wiremock-hub/shared` at runtime |

## Test Results

- Built the All-in-One image locally with this fix and ran the container:
  - backend entered RUNNING state (previously FATAL with `ERR_MODULE_NOT_FOUND`)
  - `GET /hub/` → 200, `GET /hub/api/projects` → 200, `GET /__admin/mappings` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
