### PR TITLE
feat: support fault and proxy response stubs without fixed status

### DIFF
--- a/packages/backend/src/routes/stubs.ts
+++ b/packages/backend/src/routes/stubs.ts
@@ -2,7 +2,12 @@ import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { z } from 'zod';
 import axios from 'axios';
 import { parse as parseYaml } from 'yaml';
-import { extractEqualToValues, generateSampleBody, type Mapping } from '@wiremock-hub/shared';
+import {
+  extractEqualToValues,
+  generateSampleBody,
+  isFaultOrProxyResponse,
+  type Mapping
+} from '@wiremock-hub/shared';
 import { detectFormat, buildMappingFromOperation } from '../utils/openapi-parser.js';
 import { injectHubMetadata, syncStubsToInstance } from '../utils/wiremock-sync.js';
 
@@ -382,14 +387,15 @@ export async function stubRoutes(fastify: FastifyInstance) {
           });
         }
 
-        const expectedStatus = mapping.response.status;
-        if (expectedStatus === undefined) {
-          // Fault/proxy stubs have no fixed response status to compare against
+        if (isFaultOrProxyResponse(mapping.response)) {
+          // Fault/proxy responses have no fixed status to compare against
           return reply.status(400).send({
             success: false,
             error: 'Stub has no fixed response status (fault or proxy stub) and cannot be tested'
           });
         }
+        // WireMock defaults to 200 when a stub omits an explicit status
+        const expectedStatus = mapping.response.status ?? 200;
 
         const instances = await fastify.prisma.wiremockInstance.findMany({
           where: {

--- a/packages/backend/src/routes/stubs.ts
+++ b/packages/backend/src/routes/stubs.ts
@@ -382,6 +382,15 @@ export async function stubRoutes(fastify: FastifyInstance) {
           });
         }
 
+        const expectedStatus = mapping.response.status;
+        if (expectedStatus === undefined) {
+          // Fault/proxy stubs have no fixed response status to compare against
+          return reply.status(400).send({
+            success: false,
+            error: 'Stub has no fixed response status (fault or proxy stub) and cannot be tested'
+          });
+        }
+
         const instances = await fastify.prisma.wiremockInstance.findMany({
           where: {
             projectId: stub.projectId,
@@ -396,7 +405,6 @@ export async function stubRoutes(fastify: FastifyInstance) {
           });
         }
 
-        const expectedStatus = mapping.response.status;
         let expectedBody: string | undefined;
         if (mapping.response.body) {
           expectedBody = mapping.response.body;

--- a/packages/backend/tests/routes/stubs-sync.test.ts
+++ b/packages/backend/tests/routes/stubs-sync.test.ts
@@ -237,6 +237,60 @@ describe('Stubs API - Sync & Test', () => {
       expect(response.json().error).toBe('No active WireMock instances found in this project');
     });
 
+    it('should return 400 for a fault stub without a fixed response status', async () => {
+      const app = await getTestApp();
+      const createResponse = await app.inject({
+        method: 'POST',
+        url: '/api/stubs',
+        payload: {
+          projectId,
+          name: 'Fault Stub',
+          mapping: {
+            request: { method: 'GET', url: '/api/fault' },
+            response: { fault: 'CONNECTION_RESET_BY_PEER' }
+          }
+        }
+      });
+      const stubId = createResponse.json().data.id;
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/stubs/${stubId}/test`,
+        payload: {}
+      });
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toBe(
+        'Stub has no fixed response status (fault or proxy stub) and cannot be tested'
+      );
+    });
+
+    it('should return 400 for a proxy stub without a fixed response status', async () => {
+      const app = await getTestApp();
+      const createResponse = await app.inject({
+        method: 'POST',
+        url: '/api/stubs',
+        payload: {
+          projectId,
+          name: 'Proxy Stub',
+          mapping: {
+            request: { method: 'GET', url: '/api/proxied' },
+            response: { proxyBaseUrl: 'http://upstream.example.com' }
+          }
+        }
+      });
+      const stubId = createResponse.json().data.id;
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/stubs/${stubId}/test`,
+        payload: {}
+      });
+      expect(response.statusCode).toBe(400);
+      expect(response.json().error).toBe(
+        'Stub has no fixed response status (fault or proxy stub) and cannot be tested'
+      );
+    });
+
     it('should return 400 for urlPattern without URL override', async () => {
       const app = await getTestApp();
       const createResponse = await app.inject({

--- a/packages/backend/tests/routes/stubs-sync.test.ts
+++ b/packages/backend/tests/routes/stubs-sync.test.ts
@@ -237,58 +237,57 @@ describe('Stubs API - Sync & Test', () => {
       expect(response.json().error).toBe('No active WireMock instances found in this project');
     });
 
-    it('should return 400 for a fault stub without a fixed response status', async () => {
+    it.each([
+      { label: 'fault stub', response: { fault: 'CONNECTION_RESET_BY_PEER' } },
+      // fault takes precedence in WireMock even when a status is present
+      { label: 'fault stub with a status', response: { status: 200, fault: 'EMPTY_RESPONSE' } },
+      { label: 'proxy stub', response: { proxyBaseUrl: 'http://upstream.example.com' } }
+    ])('should return 400 for a $label (no fixed response status)', async ({ response }) => {
       const app = await getTestApp();
       const createResponse = await app.inject({
         method: 'POST',
         url: '/api/stubs',
         payload: {
           projectId,
-          name: 'Fault Stub',
-          mapping: {
-            request: { method: 'GET', url: '/api/fault' },
-            response: { fault: 'CONNECTION_RESET_BY_PEER' }
-          }
+          name: 'Fault/Proxy Stub',
+          mapping: { request: { method: 'GET', url: '/api/fp' }, response }
         }
       });
       const stubId = createResponse.json().data.id;
 
-      const response = await app.inject({
+      const testResponse = await app.inject({
         method: 'POST',
         url: `/api/stubs/${stubId}/test`,
         payload: {}
       });
-      expect(response.statusCode).toBe(400);
-      expect(response.json().error).toBe(
+      expect(testResponse.statusCode).toBe(400);
+      expect(testResponse.json().error).toBe(
         'Stub has no fixed response status (fault or proxy stub) and cannot be tested'
       );
     });
 
-    it('should return 400 for a proxy stub without a fixed response status', async () => {
+    it('should treat a status-less (body-only) stub as testable, not a fault/proxy stub', async () => {
       const app = await getTestApp();
       const createResponse = await app.inject({
         method: 'POST',
         url: '/api/stubs',
         payload: {
           projectId,
-          name: 'Proxy Stub',
-          mapping: {
-            request: { method: 'GET', url: '/api/proxied' },
-            response: { proxyBaseUrl: 'http://upstream.example.com' }
-          }
+          name: 'Body-only Stub',
+          mapping: { request: { method: 'GET', url: '/api/body-only' }, response: { body: 'ok' } }
         }
       });
       const stubId = createResponse.json().data.id;
 
+      // No active instances in this project, so the request passes the fault/proxy
+      // guard (WireMock defaults to 200) and fails later on the instance check
       const response = await app.inject({
         method: 'POST',
         url: `/api/stubs/${stubId}/test`,
         payload: {}
       });
       expect(response.statusCode).toBe(400);
-      expect(response.json().error).toBe(
-        'Stub has no fixed response status (fault or proxy stub) and cannot be tested'
-      );
+      expect(response.json().error).toBe('No active WireMock instances found in this project');
     });
 
     it('should return 400 for urlPattern without URL override', async () => {

--- a/packages/frontend/src/components/mapping/StatusTag.vue
+++ b/packages/frontend/src/components/mapping/StatusTag.vue
@@ -1,0 +1,18 @@
+<template>
+  <el-tooltip :disabled="!tag.tooltip" :content="tag.tooltip" placement="top">
+    <el-tag :type="tag.type" :size="size">{{ tag.label }}</el-tag>
+  </el-tooltip>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { MappingResponse } from '@wiremock-hub/shared';
+import { statusTag } from '@/utils/wiremock';
+
+const props = defineProps<{
+  response?: MappingResponse;
+  size?: 'large' | 'default' | 'small';
+}>();
+
+const tag = computed(() => statusTag(props.response));
+</script>

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -128,6 +128,8 @@
     "method": "Method",
     "url": "URL",
     "status": "Status",
+    "faultTooltip": "Fault type: {fault}",
+    "proxyTooltip": "Proxies to: {url}",
     "priority": "Priority",
     "name": "Name",
     "scenario": "Scenario",

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -130,6 +130,7 @@
     "status": "Status",
     "faultTooltip": "Fault type: {fault}",
     "proxyTooltip": "Proxies to: {url}",
+    "testDisabledFaultProxy": "Fault/proxy stubs have no fixed response and cannot be tested",
     "priority": "Priority",
     "name": "Name",
     "scenario": "Scenario",

--- a/packages/frontend/src/i18n/locales/ja.json
+++ b/packages/frontend/src/i18n/locales/ja.json
@@ -130,6 +130,7 @@
     "status": "ステータス",
     "faultTooltip": "フォールト種別: {fault}",
     "proxyTooltip": "転送先: {url}",
+    "testDisabledFaultProxy": "フォールト/プロキシスタブは固定レスポンスがないためテストできません",
     "priority": "優先度",
     "name": "名前",
     "scenario": "シナリオ",

--- a/packages/frontend/src/i18n/locales/ja.json
+++ b/packages/frontend/src/i18n/locales/ja.json
@@ -128,6 +128,8 @@
     "method": "メソッド",
     "url": "URL",
     "status": "ステータス",
+    "faultTooltip": "フォールト種別: {fault}",
+    "proxyTooltip": "転送先: {url}",
     "priority": "優先度",
     "name": "名前",
     "scenario": "シナリオ",

--- a/packages/frontend/src/utils/wiremock.ts
+++ b/packages/frontend/src/utils/wiremock.ts
@@ -1,5 +1,6 @@
-import type { Mapping, MappingRequest } from '@wiremock-hub/shared';
+import type { Mapping, MappingRequest, MappingResponse } from '@wiremock-hub/shared';
 import type { Stub } from '@/services/api';
+import { t } from '@/i18n';
 
 /** Extract typed Mapping from Stub's mapping field */
 export function toMapping(stub: Stub): Mapping {
@@ -31,4 +32,36 @@ export function getStatusTagType(status?: number): string {
   if (status >= 400 && status < 500) return 'warning';
   if (status >= 500) return 'danger';
   return 'info';
+}
+
+export interface StatusTag {
+  type: string;
+  label: string;
+  tooltip?: string;
+}
+
+/**
+ * Describe a mapping response for the status column: fault/proxy stubs render a
+ * distinct tag with a tooltip, everything else shows the status code. Shared by
+ * the mappings, scenarios, and registered-stubs views.
+ */
+export function statusTag(response?: MappingResponse): StatusTag {
+  if (response?.fault) {
+    return {
+      type: 'danger',
+      label: 'FAULT',
+      tooltip: t('mappings.faultTooltip', { fault: response.fault })
+    };
+  }
+  if (response?.proxyBaseUrl) {
+    return {
+      type: 'info',
+      label: 'PROXY',
+      tooltip: t('mappings.proxyTooltip', { url: response.proxyBaseUrl })
+    };
+  }
+  return {
+    type: getStatusTagType(response?.status),
+    label: response?.status !== undefined ? String(response.status) : '-'
+  };
 }

--- a/packages/frontend/src/utils/wiremock.ts
+++ b/packages/frontend/src/utils/wiremock.ts
@@ -24,7 +24,8 @@ export function getUrl(request?: MappingRequest): string {
   return request.url || request.urlPattern || request.urlPath || request.urlPathPattern || '/';
 }
 
-export function getStatusTagType(status: number): string {
+export function getStatusTagType(status?: number): string {
+  if (status === undefined) return 'info';
   if (status >= 200 && status < 300) return 'success';
   if (status >= 300 && status < 400) return 'info';
   if (status >= 400 && status < 500) return 'warning';

--- a/packages/frontend/src/views/MappingEditorView.vue
+++ b/packages/frontend/src/views/MappingEditorView.vue
@@ -408,8 +408,8 @@ onMounted(async () => {
 });
 
 async function handleSave() {
-  // Validation
-  if (!formData.response.status) {
+  // Validation: fault/proxy responses have no fixed status (WireMock ignores it)
+  if (!formData.response.status && !formData.response.fault && !formData.response.proxyBaseUrl) {
     ElMessage.error(t('messages.mapping.statusRequired'));
     return;
   }

--- a/packages/frontend/src/views/MappingEditorView.vue
+++ b/packages/frontend/src/views/MappingEditorView.vue
@@ -7,10 +7,23 @@
           <el-icon><Back /></el-icon>
           {{ t('common.back') }}
         </el-button>
-        <el-button v-if="!isNew" type="success" @click="openTestDialog">
-          <el-icon><CaretRight /></el-icon>
-          {{ t('stubTest.testButton') }}
-        </el-button>
+        <el-tooltip
+          v-if="!isNew"
+          :disabled="!isFaultOrProxyResponse(formData.response)"
+          :content="t('mappings.testDisabledFaultProxy')"
+          placement="bottom"
+        >
+          <span>
+            <el-button
+              type="success"
+              :disabled="isFaultOrProxyResponse(formData.response)"
+              @click="openTestDialog"
+            >
+              <el-icon><CaretRight /></el-icon>
+              {{ t('stubTest.testButton') }}
+            </el-button>
+          </span>
+        </el-tooltip>
         <el-button type="primary" @click="handleSave" :loading="saving">
           <el-icon><Check /></el-icon>
           {{ t('common.save') }}

--- a/packages/frontend/src/views/MappingEditorView.vue
+++ b/packages/frontend/src/views/MappingEditorView.vue
@@ -126,7 +126,7 @@
             :label-position="isMobile ? 'top' : 'left'"
           >
             <!-- Status code -->
-            <el-form-item :label="t('editor.responseStatus')" required>
+            <el-form-item :label="t('editor.responseStatus')">
               <el-input-number v-model="formData.response.status" :min="100" :max="599" />
             </el-form-item>
 
@@ -224,7 +224,7 @@ import { useMappingStore } from '@/stores/mapping';
 import { useResponsive } from '@/composables/useResponsive';
 import { stubApi } from '@/services/api';
 import { ElMessage } from 'element-plus';
-import type { Mapping } from '@wiremock-hub/shared';
+import { isFaultOrProxyResponse, type Mapping } from '@wiremock-hub/shared';
 import { toMapping } from '@/utils/wiremock';
 import JsonEditor from '@/components/mapping/JsonEditor.vue';
 import KeyValueEditor from '@/components/mapping/KeyValueEditor.vue';
@@ -409,7 +409,7 @@ onMounted(async () => {
 
 async function handleSave() {
   // Validation: fault/proxy responses have no fixed status (WireMock ignores it)
-  if (!formData.response.status && !formData.response.fault && !formData.response.proxyBaseUrl) {
+  if (!formData.response.status && !isFaultOrProxyResponse(formData.response)) {
     ElMessage.error(t('messages.mapping.statusRequired'));
     return;
   }
@@ -417,6 +417,11 @@ async function handleSave() {
   if (!urlValue.value) {
     ElMessage.error(t('messages.mapping.urlRequired'));
     return;
+  }
+
+  // el-input-number emits null when cleared; drop it so no "status": null persists
+  if (formData.response.status == null) {
+    delete formData.response.status;
   }
 
   saving.value = true;

--- a/packages/frontend/src/views/MappingsView.vue
+++ b/packages/frontend/src/views/MappingsView.vue
@@ -163,18 +163,7 @@
 
       <el-table-column :label="t('mappings.status')" width="100" align="center">
         <template #default="{ row }">
-          <el-tooltip
-            v-if="statusTag(row.response).tooltip"
-            :content="statusTag(row.response).tooltip"
-            placement="top"
-          >
-            <el-tag :type="statusTag(row.response).type">{{
-              statusTag(row.response).label
-            }}</el-tag>
-          </el-tooltip>
-          <el-tag v-else :type="statusTag(row.response).type">
-            {{ statusTag(row.response).label }}
-          </el-tag>
+          <StatusTag :response="row.response" />
         </template>
       </el-table-column>
 
@@ -252,9 +241,10 @@ import { useSyncAllInstances } from '@/composables/useSyncAllInstances';
 import { useResponsive } from '@/composables/useResponsive';
 import { usePageSize } from '@/composables/usePageSize';
 import StubTestDialog from '@/components/mapping/StubTestDialog.vue';
+import StatusTag from '@/components/mapping/StatusTag.vue';
 import { ElMessage, ElMessageBox, ElTable } from 'element-plus';
 import { isFaultOrProxyResponse, type Mapping, type MappingRequest } from '@wiremock-hub/shared';
-import { getMethodTagType, getUrl, statusTag } from '@/utils/wiremock';
+import { getMethodTagType, getUrl } from '@/utils/wiremock';
 
 const { t } = useI18n();
 const router = useRouter();

--- a/packages/frontend/src/views/MappingsView.vue
+++ b/packages/frontend/src/views/MappingsView.vue
@@ -163,8 +163,22 @@
 
       <el-table-column :label="t('mappings.status')" width="100" align="center">
         <template #default="{ row }">
-          <el-tag :type="getStatusTagType(row.response.status)">
-            {{ row.response.status }}
+          <el-tooltip
+            v-if="row.response.fault"
+            :content="t('mappings.faultTooltip', { fault: row.response.fault })"
+            placement="top"
+          >
+            <el-tag type="danger">FAULT</el-tag>
+          </el-tooltip>
+          <el-tooltip
+            v-else-if="row.response.proxyBaseUrl"
+            :content="t('mappings.proxyTooltip', { url: row.response.proxyBaseUrl })"
+            placement="top"
+          >
+            <el-tag type="info">PROXY</el-tag>
+          </el-tooltip>
+          <el-tag v-else :type="getStatusTagType(row.response.status)">
+            {{ row.response.status ?? '-' }}
           </el-tag>
         </template>
       </el-table-column>

--- a/packages/frontend/src/views/MappingsView.vue
+++ b/packages/frontend/src/views/MappingsView.vue
@@ -164,21 +164,16 @@
       <el-table-column :label="t('mappings.status')" width="100" align="center">
         <template #default="{ row }">
           <el-tooltip
-            v-if="row.response.fault"
-            :content="t('mappings.faultTooltip', { fault: row.response.fault })"
+            v-if="statusTag(row.response).tooltip"
+            :content="statusTag(row.response).tooltip"
             placement="top"
           >
-            <el-tag type="danger">FAULT</el-tag>
+            <el-tag :type="statusTag(row.response).type">{{
+              statusTag(row.response).label
+            }}</el-tag>
           </el-tooltip>
-          <el-tooltip
-            v-else-if="row.response.proxyBaseUrl"
-            :content="t('mappings.proxyTooltip', { url: row.response.proxyBaseUrl })"
-            placement="top"
-          >
-            <el-tag type="info">PROXY</el-tag>
-          </el-tooltip>
-          <el-tag v-else :type="getStatusTagType(row.response.status)">
-            {{ row.response.status ?? '-' }}
+          <el-tag v-else :type="statusTag(row.response).type">
+            {{ statusTag(row.response).label }}
           </el-tag>
         </template>
       </el-table-column>
@@ -201,9 +196,22 @@
       <el-table-column :label="t('common.actions')" :width="isMobile ? 150 : 220" fixed="right">
         <template #default="{ row }">
           <el-button-group>
-            <el-button size="small" type="success" @click.stop="openTestDialog(row)">
-              <el-icon><CaretRight /></el-icon>
-            </el-button>
+            <el-tooltip
+              :disabled="!isFaultOrProxyResponse(row.response)"
+              :content="t('mappings.testDisabledFaultProxy')"
+              placement="top"
+            >
+              <span>
+                <el-button
+                  size="small"
+                  type="success"
+                  :disabled="isFaultOrProxyResponse(row.response)"
+                  @click.stop="openTestDialog(row)"
+                >
+                  <el-icon><CaretRight /></el-icon>
+                </el-button>
+              </span>
+            </el-tooltip>
             <el-button size="small" @click.stop="editMapping(row)">
               <el-icon><Edit /></el-icon>
             </el-button>
@@ -245,8 +253,8 @@ import { useResponsive } from '@/composables/useResponsive';
 import { usePageSize } from '@/composables/usePageSize';
 import StubTestDialog from '@/components/mapping/StubTestDialog.vue';
 import { ElMessage, ElMessageBox, ElTable } from 'element-plus';
-import type { Mapping, MappingRequest } from '@wiremock-hub/shared';
-import { getMethodTagType, getUrl, getStatusTagType } from '@/utils/wiremock';
+import { isFaultOrProxyResponse, type Mapping, type MappingRequest } from '@wiremock-hub/shared';
+import { getMethodTagType, getUrl, statusTag } from '@/utils/wiremock';
 
 const { t } = useI18n();
 const router = useRouter();

--- a/packages/frontend/src/views/RegisteredStubsView.vue
+++ b/packages/frontend/src/views/RegisteredStubsView.vue
@@ -89,7 +89,18 @@
           </el-table-column>
           <el-table-column :label="t('registeredStubs.status')" width="80">
             <template #default="{ row }">
-              {{ row.response?.status || '—' }}
+              <el-tooltip
+                v-if="statusTag(row.response).tooltip"
+                :content="statusTag(row.response).tooltip"
+                placement="top"
+              >
+                <el-tag :type="statusTag(row.response).type" size="small">
+                  {{ statusTag(row.response).label }}
+                </el-tag>
+              </el-tooltip>
+              <el-tag v-else :type="statusTag(row.response).type" size="small">
+                {{ statusTag(row.response).label }}
+              </el-tag>
             </template>
           </el-table-column>
           <el-table-column v-if="!isMobile" :label="t('registeredStubs.priority')" width="80">
@@ -133,7 +144,7 @@ import { useProjectStore } from '@/stores/project';
 import { wiremockInstanceApi } from '@/services/api';
 import { ElMessage, ElMessageBox } from 'element-plus';
 import type { Mapping } from '@wiremock-hub/shared';
-import { getMethodTagType, getUrl } from '@/utils/wiremock';
+import { getMethodTagType, getUrl, statusTag } from '@/utils/wiremock';
 import { useResponsive } from '@/composables/useResponsive';
 import { usePageSize } from '@/composables/usePageSize';
 

--- a/packages/frontend/src/views/RegisteredStubsView.vue
+++ b/packages/frontend/src/views/RegisteredStubsView.vue
@@ -89,18 +89,7 @@
           </el-table-column>
           <el-table-column :label="t('registeredStubs.status')" width="80">
             <template #default="{ row }">
-              <el-tooltip
-                v-if="statusTag(row.response).tooltip"
-                :content="statusTag(row.response).tooltip"
-                placement="top"
-              >
-                <el-tag :type="statusTag(row.response).type" size="small">
-                  {{ statusTag(row.response).label }}
-                </el-tag>
-              </el-tooltip>
-              <el-tag v-else :type="statusTag(row.response).type" size="small">
-                {{ statusTag(row.response).label }}
-              </el-tag>
+              <StatusTag :response="row.response" size="small" />
             </template>
           </el-table-column>
           <el-table-column v-if="!isMobile" :label="t('registeredStubs.priority')" width="80">
@@ -144,7 +133,8 @@ import { useProjectStore } from '@/stores/project';
 import { wiremockInstanceApi } from '@/services/api';
 import { ElMessage, ElMessageBox } from 'element-plus';
 import type { Mapping } from '@wiremock-hub/shared';
-import { getMethodTagType, getUrl, statusTag } from '@/utils/wiremock';
+import { getMethodTagType, getUrl } from '@/utils/wiremock';
+import StatusTag from '@/components/mapping/StatusTag.vue';
 import { useResponsive } from '@/composables/useResponsive';
 import { usePageSize } from '@/composables/usePageSize';
 

--- a/packages/frontend/src/views/ScenariosView.vue
+++ b/packages/frontend/src/views/ScenariosView.vue
@@ -147,11 +147,17 @@
                       </el-tag>
                       <code class="step-url">{{ getUrl(getMapping(step).request) }}</code>
                       <span class="step-arrow-inline">&rarr;</span>
-                      <el-tag
-                        :type="getStatusTagType(getMapping(step).response?.status)"
-                        size="small"
+                      <el-tooltip
+                        v-if="statusTag(getMapping(step).response).tooltip"
+                        :content="statusTag(getMapping(step).response).tooltip"
+                        placement="top"
                       >
-                        {{ getMapping(step).response?.status }}
+                        <el-tag :type="statusTag(getMapping(step).response).type" size="small">
+                          {{ statusTag(getMapping(step).response).label }}
+                        </el-tag>
+                      </el-tooltip>
+                      <el-tag v-else :type="statusTag(getMapping(step).response).type" size="small">
+                        {{ statusTag(getMapping(step).response).label }}
                       </el-tag>
                     </div>
 
@@ -317,7 +323,7 @@ import { ElMessage } from 'element-plus';
 import { Close, EditPen, Plus } from '@element-plus/icons-vue';
 import draggable from 'vuedraggable';
 import type { Stub } from '@/services/api';
-import { getMethodTagType, getUrl, getStatusTagType } from '@/utils/wiremock';
+import { getMethodTagType, getUrl, statusTag } from '@/utils/wiremock';
 
 const { t } = useI18n();
 const router = useRouter();

--- a/packages/frontend/src/views/ScenariosView.vue
+++ b/packages/frontend/src/views/ScenariosView.vue
@@ -147,18 +147,7 @@
                       </el-tag>
                       <code class="step-url">{{ getUrl(getMapping(step).request) }}</code>
                       <span class="step-arrow-inline">&rarr;</span>
-                      <el-tooltip
-                        v-if="statusTag(getMapping(step).response).tooltip"
-                        :content="statusTag(getMapping(step).response).tooltip"
-                        placement="top"
-                      >
-                        <el-tag :type="statusTag(getMapping(step).response).type" size="small">
-                          {{ statusTag(getMapping(step).response).label }}
-                        </el-tag>
-                      </el-tooltip>
-                      <el-tag v-else :type="statusTag(getMapping(step).response).type" size="small">
-                        {{ statusTag(getMapping(step).response).label }}
-                      </el-tag>
+                      <StatusTag :response="getMapping(step).response" size="small" />
                     </div>
 
                     <!-- New state footer -->
@@ -323,7 +312,8 @@ import { ElMessage } from 'element-plus';
 import { Close, EditPen, Plus } from '@element-plus/icons-vue';
 import draggable from 'vuedraggable';
 import type { Stub } from '@/services/api';
-import { getMethodTagType, getUrl, statusTag } from '@/utils/wiremock';
+import { getMethodTagType, getUrl } from '@/utils/wiremock';
+import StatusTag from '@/components/mapping/StatusTag.vue';
 
 const { t } = useI18n();
 const router = useRouter();

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,3 +4,4 @@ export * from './types/wiremock.js';
 // Utils
 export * from './utils/sample-body.js';
 export * from './utils/matcher-values.js';
+export * from './utils/response-kind.js';

--- a/packages/shared/src/types/wiremock.ts
+++ b/packages/shared/src/types/wiremock.ts
@@ -32,14 +32,24 @@ export interface MappingRequest {
   bodyPatterns?: BodyPattern[];
 }
 
+/** WireMock fault types — when set, all other response attributes are ignored by WireMock */
+export type WireMockFault =
+  | 'CONNECTION_RESET_BY_PEER'
+  | 'EMPTY_RESPONSE'
+  | 'MALFORMED_RESPONSE_CHUNK'
+  | 'RANDOM_DATA_THEN_CLOSE';
+
 export interface MappingResponse {
-  status: number;
+  // Optional because fault/proxy responses have no fixed status
+  status?: number;
   statusMessage?: string;
   body?: string;
   jsonBody?: unknown;
   bodyFileName?: string;
   // Multi-value response headers (e.g. Set-Cookie) are represented as string arrays
   headers?: Record<string, string | string[]>;
+  fault?: WireMockFault;
+  proxyBaseUrl?: string;
   additionalProxyRequestHeaders?: Record<string, string>;
   fixedDelayMilliseconds?: number;
   delayDistribution?: unknown;

--- a/packages/shared/src/utils/response-kind.ts
+++ b/packages/shared/src/utils/response-kind.ts
@@ -1,0 +1,11 @@
+import type { MappingResponse } from '../types/wiremock.js';
+
+/**
+ * A fault or proxy response has no fixed status code that can be asserted
+ * against: WireMock ignores `status` when `fault` is set, and a proxied
+ * response's status is determined by the upstream. Such stubs cannot be
+ * meaningfully compared in the stub test flow.
+ */
+export function isFaultOrProxyResponse(response?: Pick<MappingResponse, 'fault' | 'proxyBaseUrl'>) {
+  return Boolean(response?.fault || response?.proxyBaseUrl);
+}


### PR DESCRIPTION
## Summary

Support WireMock fault injection (`response.fault`) and proxying (`response.proxyBaseUrl`) stubs, which have no fixed response status. This is a JSON-first implementation: such stubs are authored via the JSON editor tab, and the Hub now stores, syncs, and correctly displays/guards them across every stub view.

## Reason for Change

The editor's save validation unconditionally required `response.status`, so a spec-correct fault mapping (e.g. `{"fault": "CONNECTION_RESET_BY_PEER"}`) could not be saved at all — even via the JSON tab — forcing users to add a dummy `status` that then showed up as a misleading green "200" in the stub list. Fault and proxy are core WireMock response features, and the Hub should neither block nor misrepresent them.

## Changes

### Shared

- Add `WireMockFault` union type and `fault?` / `proxyBaseUrl?` to `MappingResponse`; make `MappingResponse.status` optional (fault/proxy responses have no fixed status)
- Add `isFaultOrProxyResponse(response)` helper (single source of truth reused by the backend guard, editor validation, and the status/test-button UI)

### Frontend

- Editor save validation: `status` is required only when the response is not a fault/proxy response; on save, a null status (from clearing the number input) is dropped so no `"status": null` is persisted, and the status field's `required` marker is removed
- Test buttons are disabled for fault/proxy stubs — both in the stub list and in the editor header — with an i18n tooltip explaining why (the backend 400 remains as an API-level guard)
- New `StatusTag` component renders the status column across the mappings, scenarios, and registered-stubs views: a red `FAULT` tag (tooltip: fault type) or `PROXY` tag (tooltip: target URL), otherwise the status code (falling back to `-`)
- `getStatusTagType()` accepts `undefined`
- New i18n keys (`mappings.faultTooltip` / `proxyTooltip` / `testDisabledFaultProxy`) in Japanese and English

### Backend

- `POST /api/stubs/:id/test` returns 400 for fault/proxy stubs (they have no fixed status to compare against). Status-less body-only stubs are treated as testable and default to `200`, matching WireMock's own default.

## Modified Files

| File | Changes |
|------|---------|
| `packages/shared/src/types/wiremock.ts` | `WireMockFault` type; `fault?`/`proxyBaseUrl?`; `status` optional |
| `packages/shared/src/utils/response-kind.ts` | New — `isFaultOrProxyResponse` helper |
| `packages/shared/src/index.ts` | Export the new util |
| `packages/backend/src/routes/stubs.ts` | Test route: 400 for fault/proxy, default status 200 otherwise |
| `packages/backend/tests/routes/stubs-sync.test.ts` | `it.each` tests for fault / fault+status / proxy rejection, plus a status-less-is-testable case |
| `packages/frontend/src/components/mapping/StatusTag.vue` | New — shared status/FAULT/PROXY tag with tooltip |
| `packages/frontend/src/utils/wiremock.ts` | `statusTag()` helper; `getStatusTagType(status?)` |
| `packages/frontend/src/views/MappingEditorView.vue` | Validation for fault/proxy; drop null status; disable test button; remove required marker |
| `packages/frontend/src/views/MappingsView.vue` | Use `StatusTag`; disable test button for fault/proxy |
| `packages/frontend/src/views/RegisteredStubsView.vue` | Use `StatusTag` in status column |
| `packages/frontend/src/views/ScenariosView.vue` | Use `StatusTag` for step status |
| `packages/frontend/src/i18n/locales/ja.json` / `en.json` | Tooltip + test-disabled keys |

## Test Results

- `pnpm --filter @wiremock-hub/backend test` — 249/249 passed
- `pnpm test:e2e` (fresh demo Docker build from this branch) — 46 passed, 0 failed (1 known-flaky test passed on retry)
- `pnpm run build` / `eslint packages` / `prettier --check` — all clean
- Manual verification against live demo WireMock 3.13.2:
  - Fault stub created via JSON tab (no status) → saved → synced → `curl` gets a connection drop (exit 52); proxy stub synced → request proxied to a second WireMock and upstream body returned
  - Stub list renders `FAULT` (red) / `PROXY` (grey) / `200` (green) tags via `StatusTag`, with the test button disabled for fault/proxy rows and enabled for normal ones (verified in the DOM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
