### PR TITLE
feat: support multi-value headers and params in stub test overrides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,7 +340,6 @@ packages/
 │       ├── router/         # Routing configuration
 │       ├── services/       # API communication
 │       ├── stores/         # Pinia stores
-│       ├── types/          # TypeScript type definitions
 │       ├── utils/          # Shared utility functions
 │       └── views/          # Page components
 ├── backend/

--- a/packages/backend/src/mcp/tools/stubs.ts
+++ b/packages/backend/src/mcp/tools/stubs.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { FastifyInstance } from 'fastify';
 import { callApi, toResult } from '../helpers.js';
+import { stubTestValueMapSchema } from '../../routes/stubs.js';
 
 // WireMock mapping JSON is arbitrary; accept any object shape.
 const mappingSchema = z.record(z.string(), z.any());
@@ -104,15 +105,19 @@ export function registerStubTools(server: McpServer, fastify: FastifyInstance): 
       inputSchema: {
         id: z.string().describe('Stub ID'),
         url: z.string().optional().describe('Override request URL (required for urlPattern stubs)'),
-        headers: z
-          .record(z.string(), z.string())
+        headers: stubTestValueMapSchema
           .optional()
-          .describe('Replace request headers entirely (stub-derived headers are not merged in)'),
+          .describe(
+            'Replace request headers entirely (stub-derived headers are not merged in); ' +
+              'use a string array for multi-value headers'
+          ),
         body: z.string().optional().describe('Override request body'),
-        queryParameters: z
-          .record(z.string(), z.string())
+        queryParameters: stubTestValueMapSchema
           .optional()
-          .describe('Replace query parameters entirely (stub-derived params are not merged in)')
+          .describe(
+            'Replace query parameters entirely (stub-derived params are not merged in); ' +
+              'use a string array for multi-value parameters'
+          )
       },
       annotations: { readOnlyHint: false, openWorldHint: true }
     },

--- a/packages/backend/src/routes/stubs.ts
+++ b/packages/backend/src/routes/stubs.ts
@@ -6,7 +6,8 @@ import {
   extractEqualToValues,
   generateSampleBody,
   isFaultOrProxyResponse,
-  type Mapping
+  type Mapping,
+  type MultiValueMap
 } from '@wiremock-hub/shared';
 import { detectFormat, buildMappingFromOperation } from '../utils/openapi-parser.js';
 import { injectHubMetadata, syncStubsToInstance } from '../utils/wiremock-sync.js';
@@ -32,11 +33,18 @@ const syncStubSchema = z.object({
   instanceId: z.string().uuid()
 });
 
+// Raw value map for test requests (string or string[] for multi-value entries).
+// Exported so the MCP test_stub tool reuses the exact same shape.
+export const stubTestValueMapSchema = z.record(
+  z.string(),
+  z.union([z.string(), z.array(z.string())])
+);
+
 const stubTestSchema = z.object({
   url: z.string().optional(),
-  headers: z.record(z.string(), z.string()).optional(),
+  headers: stubTestValueMapSchema.optional(),
   body: z.string().optional(),
-  queryParameters: z.record(z.string(), z.string()).optional()
+  queryParameters: stubTestValueMapSchema.optional()
 });
 
 const importOpenApiSchema = z.object({
@@ -306,9 +314,9 @@ export async function stubRoutes(fastify: FastifyInstance) {
     mapping: Mapping,
     overrides?: {
       url?: string;
-      headers?: Record<string, string>;
+      headers?: MultiValueMap;
       body?: string;
-      queryParameters?: Record<string, string>;
+      queryParameters?: MultiValueMap;
     }
   ) {
     const method = mapping.request.method || 'GET';
@@ -425,7 +433,12 @@ export async function stubRoutes(fastify: FastifyInstance) {
             try {
               let requestUrl = `${instance.url}${testRequest.url}`;
               if (Object.keys(testRequest.queryParameters).length > 0) {
-                const params = new URLSearchParams(testRequest.queryParameters);
+                const params = new URLSearchParams();
+                for (const [key, value] of Object.entries(testRequest.queryParameters)) {
+                  for (const item of Array.isArray(value) ? value : [value]) {
+                    params.append(key, item);
+                  }
+                }
                 requestUrl += `?${params.toString()}`;
               }
 
@@ -453,7 +466,7 @@ export async function stubRoutes(fastify: FastifyInstance) {
                 actualBody:
                   typeof response.data === 'string' ? response.data : JSON.stringify(response.data),
                 expectedHeaders,
-                actualHeaders: response.headers as Record<string, string | string[]>,
+                actualHeaders: response.headers as MultiValueMap,
                 responseTimeMs
               };
             } catch (err: any) {

--- a/packages/backend/src/routes/wiremock-instances.ts
+++ b/packages/backend/src/routes/wiremock-instances.ts
@@ -896,11 +896,8 @@ function generateMapping(
     const headers: Record<string, ValueMatcher> = {};
     for (const header of options.matchHeaders) {
       const headerValue = wiremockRequest.request.headers[header];
-      // Multi-value headers arrive as arrays; buildValueMatcher emits hasExactly for them
-      if (
-        (typeof headerValue === 'string' && headerValue) ||
-        (Array.isArray(headerValue) && headerValue.length > 0)
-      ) {
+      // Non-empty string or array; buildValueMatcher emits hasExactly for arrays
+      if (headerValue && headerValue.length > 0) {
         headers[header] = buildValueMatcher(headerValue);
       }
     }

--- a/packages/backend/src/routes/wiremock-instances.ts
+++ b/packages/backend/src/routes/wiremock-instances.ts
@@ -2,7 +2,12 @@ import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { z } from 'zod';
 import axios from 'axios';
 import { gunzipSync } from 'node:zlib';
-import type { LoggedRequest } from '@wiremock-hub/shared';
+import {
+  buildValueMatcher,
+  type LoggedRequest,
+  type MultiValueMap,
+  type ValueMatcher
+} from '@wiremock-hub/shared';
 
 const createInstanceSchema = z.object({
   projectId: z.string().uuid(),
@@ -888,14 +893,15 @@ function generateMapping(
 
   // Header matching
   if (options.matchHeaders.length > 0) {
-    const headers: Record<string, { equalTo: string } | { hasExactly: { equalTo: string }[] }> = {};
+    const headers: Record<string, ValueMatcher> = {};
     for (const header of options.matchHeaders) {
       const headerValue = wiremockRequest.request.headers[header];
-      if (typeof headerValue === 'string' && headerValue) {
-        headers[header] = { equalTo: headerValue };
-      } else if (Array.isArray(headerValue) && headerValue.length > 0) {
-        // Multi-value headers arrive as arrays; match all values with hasExactly
-        headers[header] = { hasExactly: headerValue.map((value) => ({ equalTo: value })) };
+      // Multi-value headers arrive as arrays; buildValueMatcher emits hasExactly for them
+      if (
+        (typeof headerValue === 'string' && headerValue) ||
+        (Array.isArray(headerValue) && headerValue.length > 0)
+      ) {
+        headers[header] = buildValueMatcher(headerValue);
       }
     }
     if (Object.keys(headers).length > 0) {
@@ -931,7 +937,7 @@ function generateMapping(
     wiremockRequest.response?.headers || wiremockRequest.responseDefinition?.headers;
   if (options.responseHeaders.length > 0 && sourceHeaders) {
     // WireMock accepts string arrays for multi-value response headers (e.g. Set-Cookie)
-    const headers: Record<string, string | string[]> = {};
+    const headers: MultiValueMap = {};
     for (const header of options.responseHeaders) {
       if (sourceHeaders[header]) {
         headers[header] = sourceHeaders[header];

--- a/packages/backend/tests/routes/stubs-sync.test.ts
+++ b/packages/backend/tests/routes/stubs-sync.test.ts
@@ -768,6 +768,57 @@ describe('Stubs API - Sync & Test', () => {
       expect(echoedRequest.queryParameters).toEqual({ q: 'overridden' });
     });
 
+    it('should extract multi-value headers from hasExactly matchers', async () => {
+      const app = await getTestApp();
+      await createInstance(projectId);
+      const stubId = await createStub(projectId, {
+        request: {
+          method: 'GET',
+          url: '/api/multi',
+          headers: {
+            'X-Single': { equalTo: 'one' },
+            'X-Multi': { hasExactly: [{ equalTo: 'a' }, { equalTo: 'b' }] }
+          }
+        },
+        response: { status: 200 }
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/stubs/${stubId}/test`,
+        payload: {}
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().data.request.headers).toEqual({
+        'X-Single': 'one',
+        'X-Multi': ['a', 'b']
+      });
+    });
+
+    it('should accept multi-value header and query parameter overrides', async () => {
+      const app = await getTestApp();
+      await createInstance(projectId);
+      const stubId = await createStub(projectId, {
+        request: { method: 'GET', url: '/api/multi' },
+        response: { status: 200 }
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/stubs/${stubId}/test`,
+        payload: {
+          headers: { 'X-Multi': ['a', 'b'] },
+          queryParameters: { tag: ['x', 'y'] }
+        }
+      });
+
+      expect(response.statusCode).toBe(200);
+      const echoedRequest = response.json().data.request;
+      expect(echoedRequest.headers).toEqual({ 'X-Multi': ['a', 'b'] });
+      expect(echoedRequest.queryParameters).toEqual({ tag: ['x', 'y'] });
+    });
+
     it('should use body override over the generated sample', async () => {
       const app = await getTestApp();
       await createInstance(projectId);

--- a/packages/frontend/src/components/mapping/KeyValueEditor.vue
+++ b/packages/frontend/src/components/mapping/KeyValueEditor.vue
@@ -61,6 +61,9 @@ watch(
   (value) => {
     if (lastEmitted !== NOT_EMITTED && (value === undefined ? value : toRaw(value)) === lastEmitted)
       return;
+    // Record the accepted external value so a later reset to a different value
+    // (e.g. undefined) is not mistaken for an echo of our own emit
+    lastEmitted = value === undefined ? undefined : toRaw(value);
     if (value && typeof value === 'object') {
       items.value = Object.entries(value).flatMap(([key, val]) => {
         if (

--- a/packages/frontend/src/components/mapping/KeyValueEditor.vue
+++ b/packages/frontend/src/components/mapping/KeyValueEditor.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { ref, toRaw, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useResponsive } from '@/composables/useResponsive';
 
@@ -30,6 +30,13 @@ const { isMobile } = useResponsive();
 
 const props = defineProps<{
   modelValue?: Record<string, any>;
+  /**
+   * Treat values as raw strings where duplicate keys collapse into string arrays
+   * (multi-value headers/params). Leave off for WireMock matcher maps, where
+   * array values are invalid and object values (equalTo/hasExactly) round-trip
+   * through JSON strings instead.
+   */
+  multiValue?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -43,15 +50,29 @@ interface KeyValueItem {
 
 const items = ref<KeyValueItem[]>([]);
 
-// Initialization
+// Skip re-initialization when the change is our own emit echoed back via v-model,
+// so rows are not rebuilt (and reordered) while the user is typing
+const NOT_EMITTED = Symbol('not-emitted');
+let lastEmitted: Record<string, any> | undefined | typeof NOT_EMITTED = NOT_EMITTED;
+
+// Initialization: multi-value entries (string arrays) expand into one row per value
 watch(
   () => props.modelValue,
   (value) => {
+    if (lastEmitted !== NOT_EMITTED && (value === undefined ? value : toRaw(value)) === lastEmitted)
+      return;
     if (value && typeof value === 'object') {
-      items.value = Object.entries(value).map(([key, val]) => ({
-        key,
-        value: typeof val === 'string' ? val : JSON.stringify(val)
-      }));
+      items.value = Object.entries(value).flatMap(([key, val]) => {
+        if (
+          props.multiValue &&
+          Array.isArray(val) &&
+          val.length > 0 &&
+          val.every((v) => typeof v === 'string')
+        ) {
+          return val.map((v: string) => ({ key, value: v }));
+        }
+        return [{ key, value: typeof val === 'string' ? val : JSON.stringify(val) }];
+      });
     } else {
       items.value = [];
     }
@@ -68,15 +89,36 @@ function removeItem(index: number) {
   updateValue();
 }
 
+// Matcher maps hold objects (equalTo/hasExactly) that are displayed as JSON
+// strings; parse them back so editing a row does not destroy the matcher
+function parseIfJson(value: string): unknown {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return value;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
 function updateValue() {
   const result: Record<string, any> = {};
   items.value.forEach((item) => {
-    if (item.key) {
-      result[item.key] = item.value;
+    if (!item.key) return;
+    if (props.multiValue && Object.hasOwn(result, item.key)) {
+      // Rows sharing a key collapse back into a string array (multi-value headers)
+      const existing = result[item.key];
+      result[item.key] = Array.isArray(existing)
+        ? [...existing, item.value]
+        : [existing, item.value];
+    } else {
+      // Matcher maps: last row wins for duplicate keys (arrays are invalid there)
+      result[item.key] = props.multiValue ? item.value : parseIfJson(item.value);
     }
   });
 
-  emit('update:modelValue', Object.keys(result).length > 0 ? result : undefined);
+  lastEmitted = Object.keys(result).length > 0 ? result : undefined;
+  emit('update:modelValue', lastEmitted);
 }
 </script>
 

--- a/packages/frontend/src/components/mapping/StubTestDialog.vue
+++ b/packages/frontend/src/components/mapping/StubTestDialog.vue
@@ -31,11 +31,11 @@
       </el-form-item>
 
       <el-form-item :label="t('stubTest.headers')">
-        <KeyValueEditor v-model="requestHeaders" />
+        <KeyValueEditor v-model="requestHeaders" multi-value />
       </el-form-item>
 
       <el-form-item :label="t('stubTest.queryParameters')">
-        <KeyValueEditor v-model="requestQueryParams" />
+        <KeyValueEditor v-model="requestQueryParams" multi-value />
       </el-form-item>
 
       <el-form-item :label="t('stubTest.body')">
@@ -173,6 +173,7 @@ import { storeToRefs } from 'pinia';
 import {
   extractEqualToValues,
   generateSampleBody,
+  type MultiValueMap,
   type StubTestRequest
 } from '@wiremock-hub/shared';
 import KeyValueEditor from '@/components/mapping/KeyValueEditor.vue';
@@ -198,8 +199,8 @@ const { testResult, testError, testing } = storeToRefs(mappingStore);
 const stubName = ref('');
 const requestMethod = ref('GET');
 const requestUrl = ref('');
-const requestHeaders = ref<Record<string, string> | undefined>({});
-const requestQueryParams = ref<Record<string, string> | undefined>({});
+const requestHeaders = ref<MultiValueMap | undefined>({});
+const requestQueryParams = ref<MultiValueMap | undefined>({});
 const requestBody = ref('');
 const bodyHints = ref<string[]>([]);
 const isPatternUrl = ref(false);

--- a/packages/frontend/src/views/MappingEditorView.vue
+++ b/packages/frontend/src/views/MappingEditorView.vue
@@ -237,7 +237,7 @@ import { useMappingStore } from '@/stores/mapping';
 import { useResponsive } from '@/composables/useResponsive';
 import { stubApi } from '@/services/api';
 import { ElMessage } from 'element-plus';
-import { isFaultOrProxyResponse, type Mapping } from '@wiremock-hub/shared';
+import { isFaultOrProxyResponse, joinMultiValue, type Mapping } from '@wiremock-hub/shared';
 import { toMapping } from '@/utils/wiremock';
 import JsonEditor from '@/components/mapping/JsonEditor.vue';
 import KeyValueEditor from '@/components/mapping/KeyValueEditor.vue';
@@ -279,8 +279,7 @@ const responseBody = computed({
     }
     // Try to parse as JSON and store as jsonBody if Content-Type is JSON
     // (multi-value headers are arrays, so normalize before matching)
-    const rawContentType = formData.response.headers?.['Content-Type'] || '';
-    const contentType = Array.isArray(rawContentType) ? rawContentType.join(',') : rawContentType;
+    const contentType = joinMultiValue(formData.response.headers?.['Content-Type'] || '');
     if (contentType.includes('json')) {
       try {
         formData.response.jsonBody = JSON.parse(val);

--- a/packages/frontend/src/views/MappingEditorView.vue
+++ b/packages/frontend/src/views/MappingEditorView.vue
@@ -145,7 +145,7 @@
 
             <!-- Response headers -->
             <el-form-item :label="t('editor.responseHeaders')">
-              <KeyValueEditor v-model="formData.response.headers" />
+              <KeyValueEditor v-model="formData.response.headers" multi-value />
             </el-form-item>
 
             <!-- Response body -->
@@ -278,7 +278,9 @@ const responseBody = computed({
       return;
     }
     // Try to parse as JSON and store as jsonBody if Content-Type is JSON
-    const contentType = formData.response.headers?.['Content-Type'] || '';
+    // (multi-value headers are arrays, so normalize before matching)
+    const rawContentType = formData.response.headers?.['Content-Type'] || '';
+    const contentType = Array.isArray(rawContentType) ? rawContentType.join(',') : rawContentType;
     if (contentType.includes('json')) {
       try {
         formData.response.jsonBody = JSON.parse(val);

--- a/packages/frontend/src/views/RequestDetailView.vue
+++ b/packages/frontend/src/views/RequestDetailView.vue
@@ -141,7 +141,7 @@ import { useI18n } from 'vue-i18n';
 import { ElMessage } from 'element-plus';
 import { ArrowLeft } from '@element-plus/icons-vue';
 import dayjs from 'dayjs';
-import type { LoggedRequest } from '@wiremock-hub/shared';
+import { joinMultiValue, type LoggedRequest } from '@wiremock-hub/shared';
 import { getMethodTagType, getStatusTagType } from '@/utils/wiremock';
 import api from '@/services/api';
 import ImportStubDialog from '@/components/request/ImportStubDialog.vue';
@@ -164,7 +164,7 @@ const requestHeaders = computed(() => {
   if (!request.value?.request.headers) return [];
   return Object.entries(request.value.request.headers).map(([name, value]) => ({
     name,
-    value: Array.isArray(value) ? value.join(', ') : String(value)
+    value: joinMultiValue(value)
   }));
 });
 
@@ -173,7 +173,7 @@ const responseHeaders = computed(() => {
   if (!headers) return [];
   return Object.entries(headers).map(([name, value]) => ({
     name,
-    value: Array.isArray(value) ? value.join(', ') : String(value)
+    value: joinMultiValue(value)
   }));
 });
 
@@ -181,7 +181,7 @@ const queryParams = computed(() => {
   if (!request.value?.request.queryParams) return [];
   return Object.entries(request.value.request.queryParams).map(([name, value]) => ({
     name,
-    value: Array.isArray(value?.values) ? value.values.join(', ') : String(value)
+    value: Array.isArray(value?.values) ? joinMultiValue(value.values) : String(value)
   }));
 });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,3 +5,4 @@ export * from './types/wiremock.js';
 export * from './utils/sample-body.js';
 export * from './utils/matcher-values.js';
 export * from './utils/response-kind.js';
+export * from './utils/multi-value.js';

--- a/packages/shared/src/types/wiremock.ts
+++ b/packages/shared/src/types/wiremock.ts
@@ -1,3 +1,9 @@
+/**
+ * Raw header/parameter value map where multi-value entries (e.g. repeated
+ * Set-Cookie headers) are represented as string arrays.
+ */
+export type MultiValueMap = Record<string, string | string[]>;
+
 export interface Mapping {
   id?: string;
   uuid?: string;
@@ -47,7 +53,7 @@ export interface MappingResponse {
   jsonBody?: unknown;
   bodyFileName?: string;
   // Multi-value response headers (e.g. Set-Cookie) are represented as string arrays
-  headers?: Record<string, string | string[]>;
+  headers?: MultiValueMap;
   fault?: WireMockFault;
   proxyBaseUrl?: string;
   additionalProxyRequestHeaders?: Record<string, string>;
@@ -83,7 +89,7 @@ export interface LoggedRequest {
     method: string;
     clientIp?: string;
     // Multi-value headers are serialized as string arrays in the journal
-    headers: Record<string, string | string[]>;
+    headers: MultiValueMap;
     cookies?: Record<string, unknown>;
     body?: string;
     bodyAsBase64?: string;
@@ -95,11 +101,11 @@ export interface LoggedRequest {
   responseDefinition?: {
     status: number;
     body?: string;
-    headers?: Record<string, string | string[]>;
+    headers?: MultiValueMap;
   };
   response?: {
     status: number;
-    headers?: Record<string, string | string[]>;
+    headers?: MultiValueMap;
     body?: string;
     bodyAsBase64?: string;
   };
@@ -131,9 +137,10 @@ export interface RequestsResponse {
 /** Test request overrides (fields the user can edit before sending) */
 export interface StubTestRequest {
   url?: string;
-  headers?: Record<string, string>;
+  // Multi-value headers/params (from hasExactly matchers) are sent as string arrays
+  headers?: MultiValueMap;
   body?: string;
-  queryParameters?: Record<string, string>;
+  queryParameters?: MultiValueMap;
 }
 
 /** Test result per instance */
@@ -147,8 +154,8 @@ export interface StubTestInstanceResult {
   actualStatus: number;
   expectedBody?: string;
   actualBody?: string;
-  expectedHeaders?: Record<string, string | string[]>;
-  actualHeaders?: Record<string, string | string[]>;
+  expectedHeaders?: MultiValueMap;
+  actualHeaders?: MultiValueMap;
   error?: string;
   responseTimeMs?: number;
 }
@@ -160,8 +167,8 @@ export interface StubTestResponse {
   request: {
     method: string;
     url: string;
-    headers?: Record<string, string>;
-    queryParameters?: Record<string, string>;
+    headers?: MultiValueMap;
+    queryParameters?: MultiValueMap;
     body?: string;
   };
   results: StubTestInstanceResult[];

--- a/packages/shared/src/utils/matcher-values.ts
+++ b/packages/shared/src/utils/matcher-values.ts
@@ -1,19 +1,39 @@
+import type { MultiValueMap } from '../types/wiremock.js';
+
 /**
  * Extract concrete values from WireMock matcher maps (request headers / query
- * parameters), keeping only matchers with a string `equalTo` value.
+ * parameters). Supports string `equalTo` matchers and multi-value
+ * `hasExactly: [{ equalTo }, ...]` matchers (arrays of the inner values).
  */
-export function extractEqualToValues(matchers?: Record<string, unknown>): Record<string, string> {
-  const values: Record<string, string> = {};
+export function extractEqualToValues(matchers?: Record<string, unknown>): MultiValueMap {
+  const values: MultiValueMap = {};
   if (!matchers) return values;
   for (const [key, matcher] of Object.entries(matchers)) {
-    if (
-      typeof matcher === 'object' &&
-      matcher !== null &&
-      'equalTo' in matcher &&
-      typeof (matcher as Record<string, unknown>).equalTo === 'string'
-    ) {
-      values[key] = (matcher as { equalTo: string }).equalTo;
+    if (typeof matcher !== 'object' || matcher === null) continue;
+    const { equalTo, hasExactly } = matcher as { equalTo?: unknown; hasExactly?: unknown };
+    if (typeof equalTo === 'string') {
+      values[key] = equalTo;
+    } else if (Array.isArray(hasExactly)) {
+      const inner = hasExactly
+        .map((entry) => (entry as { equalTo?: unknown } | null)?.equalTo)
+        .filter((value): value is string => typeof value === 'string');
+      if (inner.length > 0) {
+        values[key] = inner;
+      }
     }
   }
   return values;
+}
+
+export type ValueMatcher = { equalTo: string } | { hasExactly: { equalTo: string }[] };
+
+/**
+ * Build a WireMock matcher for a request header / query parameter value:
+ * a single string becomes `{ equalTo }`, multiple values become
+ * `{ hasExactly: [{ equalTo }, ...] }`. Inverse of `extractEqualToValues`.
+ */
+export function buildValueMatcher(value: string | string[]): ValueMatcher {
+  return typeof value === 'string'
+    ? { equalTo: value }
+    : { hasExactly: value.map((v) => ({ equalTo: v })) };
 }

--- a/packages/shared/src/utils/multi-value.ts
+++ b/packages/shared/src/utils/multi-value.ts
@@ -1,0 +1,8 @@
+/**
+ * Render a header/parameter value for display: multi-value entries (string
+ * arrays) are joined, single values are stringified. Centralizes the
+ * `Array.isArray(v) ? v.join(...) : String(v)` pattern used across views.
+ */
+export function joinMultiValue(value: string | string[], separator = ', '): string {
+  return Array.isArray(value) ? value.join(separator) : String(value);
+}


### PR DESCRIPTION
## Summary

Complete multi-value header/parameter support in the stub test flow, and harden the key-value editor so array-collapse behavior is opt-in (WireMock matcher maps are never given invalid array values) and matcher objects (`equalTo` / `hasExactly`) survive editing instead of being destroyed as JSON strings.

## Reason for Change

WireMock represents repeated headers/parameters (e.g. `Set-Cookie`) as string arrays in the request journal, but the stub test flow and key-value editor only handled single string values. This produced several concrete defects:

- The key-value editor collapsed duplicate keys into arrays unconditionally, so entering two rows with the same key in the request-header matcher fields produced `{"X-Tag": ["a","b"]}` — an invalid WireMock matcher that syncs verbatim and silently never matches.
- Editing a row whose value is a matcher object (`{equalTo}` / `{hasExactly}`) wrote the value back as a JSON string, breaking the matcher on sync.
- `item.key in result` consulted the prototype chain, so keys like `toString` merged a function into the emitted map and failed backend validation.
- With `MappingResponse.headers` allowing `string | string[]`, the JSON Content-Type detection (`contentType.includes('json')`) silently returned false for array values.
- Empty-array values expanded to zero editor rows and were silently dropped on the next edit.
- The editor's echo-suppression guard swallowed a legitimate external reset to `undefined`, leaving stale rows on screen (and re-emitting them on the next edit).

The remaining changes remove duplication surfaced along the way (hand-synced zod schemas, handwritten `Record<string, string | string[]>` across packages, encode/decode split across packages, and a repeated array-or-string join pattern).

## Changes

### Frontend

- `KeyValueEditor`: new `multiValue` prop — duplicate-key→array collapse and array expansion only apply to raw value maps (stub test dialog, response headers); matcher maps keep last-wins semantics
- `KeyValueEditor`: values that look like JSON are parsed back on emit in matcher mode, so `equalTo`/`hasExactly` matchers round-trip through editing; `Object.hasOwn` replaces `in`; empty arrays fall back to a `"[]"` row instead of disappearing
- `KeyValueEditor`: the watch records the accepted external value so a later reset (e.g. to `undefined` via the JSON tab) is no longer mistaken for an echo of its own emit, and stale rows are cleared
- Stub test dialog sends multi-value overrides (`string | string[]`) for headers and query parameters
- `MappingEditorView`: `multi-value` on the response-headers editor; Content-Type detection normalizes array header values via the shared `joinMultiValue` helper before matching `json`
- `RequestDetailView`: request/response header and query-param rendering uses the shared `joinMultiValue` helper (was three inline copies with an inconsistent separator)

### Backend

- Stub test route and schema accept `string | string[]` override values; the value-map zod schema is exported and reused by the MCP `test_stub` tool (previously hand-synced in two places)
- `generateMapping` uses shared `buildValueMatcher` for header matchers, and its header guard is simplified to a single `headerValue && headerValue.length > 0` check

### Shared

- New `MultiValueMap` type replaces the handwritten `Record<string, string | string[]>` occurrences across all three packages
- New `buildValueMatcher` (string → `{equalTo}`, array → `{hasExactly}`) lives next to its inverse `extractEqualToValues`, with a `ValueMatcher` type
- New `joinMultiValue(value, separator = ', ')` helper centralizes the array-or-string join used by the views

### Other

- CLAUDE.md: remove the deleted `frontend/src/types/` directory from the structure diagram

## Modified Files

| File | Changes |
|------|---------|
| `packages/frontend/src/components/mapping/KeyValueEditor.vue` | `multiValue` prop, JSON parse-back, `Object.hasOwn`, empty-array guard, echo-suppression fix for external resets |
| `packages/frontend/src/components/mapping/StubTestDialog.vue` | Multi-value overrides, `multi-value` editors, `MultiValueMap` |
| `packages/frontend/src/views/MappingEditorView.vue` | `multi-value` on response headers editor, Content-Type normalization via `joinMultiValue` |
| `packages/frontend/src/views/RequestDetailView.vue` | Header / query-param rendering via shared `joinMultiValue` |
| `packages/backend/src/routes/stubs.ts` | Multi-value test overrides; export `stubTestValueMapSchema`; `MultiValueMap` |
| `packages/backend/src/mcp/tools/stubs.ts` | Reuse `stubTestValueMapSchema` in `test_stub` input schema |
| `packages/backend/src/routes/wiremock-instances.ts` | Use shared `buildValueMatcher` / `MultiValueMap`; simplified header guard |
| `packages/shared/src/types/wiremock.ts` | `MultiValueMap` type; StubTest types widened to multi-value |
| `packages/shared/src/utils/matcher-values.ts` | `buildValueMatcher` + `ValueMatcher`; typed with `MultiValueMap` |
| `packages/shared/src/utils/multi-value.ts` | New `joinMultiValue` helper |
| `packages/shared/src/index.ts` | Export new util |
| `packages/backend/tests/routes/stubs-sync.test.ts` | Tests for multi-value test overrides |
| `CLAUDE.md` | Directory diagram cleanup |

## Test Results

- `pnpm --filter @wiremock-hub/backend test` — 251/251 passed
- `pnpm test:e2e` (fresh demo Docker build from this branch's tree) — 46 passed, 0 failed (1 known-flaky test passed on retry)
- `pnpm run build` — shared/backend/frontend all clean
- `eslint packages` / `prettier --check 'packages/**'` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
