### PR TITLE
fix: preserve exact body patterns created via the Body Patterns editor

### DIFF
--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -161,7 +161,7 @@
     "queryParameters": "Query Parameters",
     "text": "Text",
     "bodyPatterns": "Body Patterns",
-    "bodyTextTabDisabled": "Text editing is disabled because this body cannot be represented as a single equalTo/equalToJson matcher. Edit it in the Body Patterns or JSON tab",
+    "bodyTextTabDisabled": "Text editing is disabled because this body cannot be edited as plain text. Edit it in the Body Patterns or JSON tab",
     "responseStatus": "Status Code",
     "responseBody": "Response Body",
     "responseHeaders": "Response Headers",

--- a/packages/frontend/src/i18n/locales/en.json
+++ b/packages/frontend/src/i18n/locales/en.json
@@ -161,7 +161,7 @@
     "queryParameters": "Query Parameters",
     "text": "Text",
     "bodyPatterns": "Body Patterns",
-    "bodyTextTabDisabled": "Text editing is disabled because the body patterns include matchers other than equalTo/equalToJson. Edit them in the Body Patterns or JSON tab",
+    "bodyTextTabDisabled": "Text editing is disabled because this body cannot be represented as a single equalTo/equalToJson matcher. Edit it in the Body Patterns or JSON tab",
     "responseStatus": "Status Code",
     "responseBody": "Response Body",
     "responseHeaders": "Response Headers",

--- a/packages/frontend/src/i18n/locales/ja.json
+++ b/packages/frontend/src/i18n/locales/ja.json
@@ -161,7 +161,7 @@
     "queryParameters": "クエリパラメータ",
     "text": "テキスト",
     "bodyPatterns": "ボディパターン",
-    "bodyTextTabDisabled": "このボディは単一の equalTo / equalToJson では表せないため、テキスト編集は無効です。ボディパターンまたはJSONタブで編集してください",
+    "bodyTextTabDisabled": "このボディはテキストとして編集できない形式のため、テキスト編集は無効です。ボディパターンまたはJSONタブで編集してください",
     "responseStatus": "ステータスコード",
     "responseBody": "レスポンスボディ",
     "responseHeaders": "レスポンスヘッダー",

--- a/packages/frontend/src/i18n/locales/ja.json
+++ b/packages/frontend/src/i18n/locales/ja.json
@@ -161,7 +161,7 @@
     "queryParameters": "クエリパラメータ",
     "text": "テキスト",
     "bodyPatterns": "ボディパターン",
-    "bodyTextTabDisabled": "equalTo / equalToJson 以外のボディパターンが含まれるため、テキスト編集は無効です。ボディパターンまたはJSONタブで編集してください",
+    "bodyTextTabDisabled": "このボディは単一の equalTo / equalToJson では表せないため、テキスト編集は無効です。ボディパターンまたはJSONタブで編集してください",
     "responseStatus": "ステータスコード",
     "responseBody": "レスポンスボディ",
     "responseHeaders": "レスポンスヘッダー",

--- a/packages/frontend/src/views/MappingEditorView.vue
+++ b/packages/frontend/src/views/MappingEditorView.vue
@@ -113,15 +113,20 @@
                   <el-tab-pane
                     :label="t('editor.text')"
                     name="text"
-                    :disabled="hasNonExactBodyPattern"
+                    :disabled="!bodyTextRepresentable"
                   >
-                    <MonacoEditor v-model="requestBodyText" language="json" height="300px" />
+                    <MonacoEditor
+                      :model-value="requestBodyText"
+                      language="json"
+                      height="300px"
+                      @update:model-value="onRequestBodyTextInput"
+                    />
                   </el-tab-pane>
                   <el-tab-pane :label="t('editor.bodyPatterns')" name="patterns">
                     <BodyPatternsEditor v-model="formData.request.bodyPatterns" />
                   </el-tab-pane>
                 </el-tabs>
-                <div v-if="hasNonExactBodyPattern" class="body-text-disabled-hint">
+                <div v-if="!bodyTextRepresentable" class="body-text-disabled-hint">
                   {{ t('editor.bodyTextTabDisabled') }}
                 </div>
               </div>
@@ -265,6 +270,15 @@ const urlValue = ref('');
 const requestBodyText = ref('');
 const requestBodyMatchType = ref<'equalTo' | 'equalToJson'>('equalTo');
 const requestBodyTab = ref('text');
+// True only after the user edits the Text field. Gates the Text -> bodyPatterns
+// flush so that merely viewing the Text tab never rewrites (and thus collapses or
+// strips) patterns the user built on the Body Patterns tab.
+const requestBodyTextDirty = ref(false);
+
+function onRequestBodyTextInput(value: string) {
+  requestBodyText.value = value;
+  requestBodyTextDirty.value = true;
+}
 
 const isNew = computed(() => route.name === 'mapping-new');
 
@@ -315,19 +329,29 @@ const formData = reactive<Mapping>({
   persistent: true
 });
 
-// Patterns the text helper cannot represent (matchesJsonPath, contains, matches, ...)
-// are managed via the Body Patterns / JSON editors; the Text tab is disabled for them.
+// The Text tab is a single-body helper that can only round-trip a lone, bare
+// equalTo / equalToJson string matcher. Anything it cannot represent faithfully —
+// non-exact matchers (contains, matches, ...), multiple patterns, sibling flags
+// (ignoreArrayOrder, ...), or a parsed-object equalToJson — is edited via the Body
+// Patterns / JSON tabs instead, so the Text tab is disabled for those.
 // NOTE: must be declared after formData — the immediate watch evaluates the computed during setup.
-const hasNonExactBodyPattern = computed(() =>
-  (formData.request?.bodyPatterns ?? []).some(
-    (p) => p.equalTo === undefined && p.equalToJson === undefined
-  )
-);
+const bodyTextRepresentable = computed(() => {
+  const bodyPatterns = formData.request?.bodyPatterns ?? [];
+  if (bodyPatterns.length === 0) return true;
+  if (bodyPatterns.length > 1) return false;
+  const bp = bodyPatterns[0] as Record<string, unknown>;
+  const keys = Object.keys(bp);
+  if (keys.length !== 1) return false;
+  return (
+    (keys[0] === 'equalTo' && typeof bp.equalTo === 'string') ||
+    (keys[0] === 'equalToJson' && typeof bp.equalToJson === 'string')
+  );
+});
 
 watch(
-  hasNonExactBodyPattern,
-  (disabled) => {
-    if (disabled && requestBodyTab.value === 'text') {
+  bodyTextRepresentable,
+  (representable) => {
+    if (!representable && requestBodyTab.value === 'text') {
       requestBodyTab.value = 'patterns';
     }
   },
@@ -382,35 +406,45 @@ function syncHelperRefsFromRequest(req: Mapping['request']) {
 }
 
 // Derive the Text-tab helper (requestBodyText / requestBodyMatchType) from the
-// first exact body pattern. Non-exact patterns leave the (disabled) Text tab empty.
+// first body pattern. Only bare equalTo / equalToJson string matchers reach the
+// Text tab (see bodyTextRepresentable); a non-string equalToJson is stringified
+// defensively so Monaco never receives a raw object. Loading resets the dirty flag.
 function syncBodyTextFromPatterns(bodyPatterns?: BodyPattern[]) {
   const bp = bodyPatterns?.[0];
-  if (bp?.equalToJson) {
-    requestBodyText.value = bp.equalToJson;
+  if (bp?.equalToJson !== undefined) {
+    requestBodyText.value =
+      typeof bp.equalToJson === 'string' ? bp.equalToJson : JSON.stringify(bp.equalToJson, null, 2);
     requestBodyMatchType.value = 'equalToJson';
   } else {
     requestBodyText.value = bp?.equalTo || '';
     requestBodyMatchType.value = 'equalTo';
   }
+  requestBodyTextDirty.value = false;
 }
 
-// Persist the Text-tab helper into formData.request.bodyPatterns. No-op when
-// non-exact patterns are present (the Text tab is disabled for them).
+// Persist the Text-tab helper into formData.request.bodyPatterns. Only runs when
+// the user actually edited the Text field and the body is text-representable, so
+// merely viewing the Text tab never collapses multi-pattern bodies, strips sibling
+// flags, or deletes an empty-body ({ equalTo: '' }) matcher.
 function flushBodyTextToPatterns() {
-  if (hasNonExactBodyPattern.value) return;
+  if (!requestBodyTextDirty.value || !bodyTextRepresentable.value) return;
   if (requestBodyText.value) {
     formData.request.bodyPatterns = [{ [requestBodyMatchType.value]: requestBodyText.value }];
   } else {
     delete formData.request.bodyPatterns;
   }
+  requestBodyTextDirty.value = false;
 }
 
 // Keep the two body editors consistent when switching tabs so the active tab
-// always reflects the current body ("what you see is what gets saved").
+// always reflects the current body ("what you see is what gets saved"). Tabs are
+// binary, so a fired watcher is always a real switch in one direction or the other.
 watch(requestBodyTab, (tab, prev) => {
-  if (tab === prev) return;
-  if (prev === 'text') flushBodyTextToPatterns();
-  if (tab === 'text') syncBodyTextFromPatterns(formData.request.bodyPatterns);
+  if (prev === 'text') {
+    flushBodyTextToPatterns();
+  } else if (tab === 'text') {
+    syncBodyTextFromPatterns(formData.request.bodyPatterns);
+  }
 });
 
 // Initialization

--- a/packages/frontend/src/views/MappingEditorView.vue
+++ b/packages/frontend/src/views/MappingEditorView.vue
@@ -422,10 +422,13 @@ function syncBodyTextFromPatterns(bodyPatterns?: BodyPattern[]) {
   requestBodyTextDirty.value = false;
 }
 
-// Persist the Text-tab helper into formData.request.bodyPatterns. Only runs when
-// the user actually edited the Text field and the body is text-representable, so
-// merely viewing the Text tab never collapses multi-pattern bodies, strips sibling
-// flags, or deletes an empty-body ({ equalTo: '' }) matcher.
+// Persist the Text-tab helper into formData.request.bodyPatterns. Runs only when the
+// user actually edited the Text field (dirty) and the body is text-representable.
+// The dirty guard means merely viewing the Text tab never rewrites bodyPatterns, so a
+// lone { equalTo: '' } matcher survives a view — though explicitly clearing the field
+// still deletes it (the Text tab can't tell "no body" from "empty-string match").
+// Multi-pattern / sibling-flag / object-equalToJson bodies keep the Text tab disabled,
+// so they never reach this flush at all.
 function flushBodyTextToPatterns() {
   if (!requestBodyTextDirty.value || !bodyTextRepresentable.value) return;
   if (requestBodyText.value) {

--- a/packages/frontend/src/views/MappingEditorView.vue
+++ b/packages/frontend/src/views/MappingEditorView.vue
@@ -237,7 +237,12 @@ import { useMappingStore } from '@/stores/mapping';
 import { useResponsive } from '@/composables/useResponsive';
 import { stubApi } from '@/services/api';
 import { ElMessage } from 'element-plus';
-import { isFaultOrProxyResponse, joinMultiValue, type Mapping } from '@wiremock-hub/shared';
+import {
+  isFaultOrProxyResponse,
+  joinMultiValue,
+  type BodyPattern,
+  type Mapping
+} from '@wiremock-hub/shared';
 import { toMapping } from '@/utils/wiremock';
 import JsonEditor from '@/components/mapping/JsonEditor.vue';
 import KeyValueEditor from '@/components/mapping/KeyValueEditor.vue';
@@ -373,20 +378,40 @@ function syncHelperRefsFromRequest(req: Mapping['request']) {
     urlValue.value = '';
   }
 
-  if (req.bodyPatterns && req.bodyPatterns[0]) {
-    const bp = req.bodyPatterns[0];
-    if (bp.equalToJson) {
-      requestBodyText.value = bp.equalToJson;
-      requestBodyMatchType.value = 'equalToJson';
-    } else {
-      requestBodyText.value = bp.equalTo || '';
-      requestBodyMatchType.value = 'equalTo';
-    }
+  syncBodyTextFromPatterns(req.bodyPatterns);
+}
+
+// Derive the Text-tab helper (requestBodyText / requestBodyMatchType) from the
+// first exact body pattern. Non-exact patterns leave the (disabled) Text tab empty.
+function syncBodyTextFromPatterns(bodyPatterns?: BodyPattern[]) {
+  const bp = bodyPatterns?.[0];
+  if (bp?.equalToJson) {
+    requestBodyText.value = bp.equalToJson;
+    requestBodyMatchType.value = 'equalToJson';
   } else {
-    requestBodyText.value = '';
+    requestBodyText.value = bp?.equalTo || '';
     requestBodyMatchType.value = 'equalTo';
   }
 }
+
+// Persist the Text-tab helper into formData.request.bodyPatterns. No-op when
+// non-exact patterns are present (the Text tab is disabled for them).
+function flushBodyTextToPatterns() {
+  if (hasNonExactBodyPattern.value) return;
+  if (requestBodyText.value) {
+    formData.request.bodyPatterns = [{ [requestBodyMatchType.value]: requestBodyText.value }];
+  } else {
+    delete formData.request.bodyPatterns;
+  }
+}
+
+// Keep the two body editors consistent when switching tabs so the active tab
+// always reflects the current body ("what you see is what gets saved").
+watch(requestBodyTab, (tab, prev) => {
+  if (tab === prev) return;
+  if (prev === 'text') flushBodyTextToPatterns();
+  if (tab === 'text') syncBodyTextFromPatterns(formData.request.bodyPatterns);
+});
 
 // Initialization
 onMounted(async () => {
@@ -440,14 +465,12 @@ async function handleSave() {
 
   saving.value = true;
   try {
-    // Sync request body text to bodyPatterns (preserve match type).
-    // Non-exact patterns are kept as-is; their Text tab is disabled in the UI.
-    if (!hasNonExactBodyPattern.value) {
-      if (requestBodyText.value) {
-        formData.request.bodyPatterns = [{ [requestBodyMatchType.value]: requestBodyText.value }];
-      } else {
-        delete formData.request.bodyPatterns;
-      }
+    // Sync the Text tab into bodyPatterns only when it is the active editor. On the
+    // Body Patterns tab, formData.request.bodyPatterns is already maintained by
+    // BodyPatternsEditor (v-model), so overwriting it from the empty/stale Text
+    // field would silently drop exact (equalTo / equalToJson) patterns.
+    if (requestBodyTab.value === 'text') {
+      flushBodyTextToPatterns();
     }
 
     if (isNew.value) {


### PR DESCRIPTION
## Summary

Fixes a silent data-loss bug in the stub editor: **exact (`equalTo` / `equalToJson`) body patterns created or edited on the "Body Patterns" tab were dropped on save**, plus a set of related body-sync edge cases (multiple patterns, `equalToJson` sibling flags, empty-body matchers).

## Reason for Change

The stub editor has two editors for the request body (Request → Request Body):

- **Text tab** — a single body via `requestBodyText` + `requestBodyMatchType` (`equalTo` / `equalToJson`)
- **Body Patterns tab** — full `bodyPatterns[]` via `BodyPatternsEditor` (`v-model` on `formData.request.bodyPatterns`)

`handleSave` unconditionally re-derived `bodyPatterns` from the Text tab whenever the patterns were exact. But `requestBodyText` is only populated on load, so building an `equalTo` / `equalToJson` pattern on the **Body Patterns tab** left it empty and the save **deleted the pattern** (or overwrote it with the stale Text value).

**Reproduced:** add an `Equal To` pattern `{"exact":"match"}` on the Body Patterns tab, save → the persisted mapping had no `bodyPatterns` at all.

## Fix

- **Gate the Text→bodyPatterns sync on the active tab.** On the Body Patterns tab, `formData.request.bodyPatterns` (kept live by `BodyPatternsEditor`) is trusted as-is; the Text helper only writes back when the Text tab is active. On tab switch, flush/reload between the two editors so the active tab always reflects the current body.
- **Disable the Text tab for any body it cannot faithfully round-trip** — multiple patterns, sibling flags (`ignoreArrayOrder`, `ignoreExtraElements`), or a parsed-object `equalToJson` — not just non-exact matchers. Prevents the flush from collapsing multi-pattern bodies to their first entry or stripping `equalToJson` flags.
- **Only flush when the user actually edited the Text field** (`requestBodyTextDirty`). Merely *viewing* the Text tab no longer deletes an empty `{ equalTo: "" }` matcher, collapses/strips patterns, or needlessly rebuilds the `BodyPatternsEditor` rows on an untouched tab round-trip. (An explicit edit that clears the field still removes the body — the Text tab can't distinguish "no body" from "empty-string match".)
- Defensively stringify a non-string `equalToJson` so Monaco never receives a raw object; reword the disabled-tab hint to state the body isn't editable as plain text.

## Modified Files

| File | Changes |
|------|---------|
| `packages/frontend/src/views/MappingEditorView.vue` | Active-tab-gated + dirty-gated Text↔bodyPatterns sync; broaden Text-tab-disabled to non-representable bodies; defensive `equalToJson` stringify |
| `packages/frontend/src/i18n/locales/{ja,en}.json` | Reword the `bodyTextTabDisabled` hint |

## Test Results

Verified end-to-end (dev frontend build + running backend, checked via the API):

- Body Patterns tab → `equalTo` → save → preserved (previously dropped)
- Text entry → switch to Body Patterns tab → save → preserved
- **Multiple exact patterns** `[{equalTo:'a'},{equalTo:'b'}]` → Text tab disabled, both preserved
- **`equalToJson` object + `ignoreArrayOrder`/`ignoreExtraElements`** → Text tab disabled, object and flags preserved
- **Empty `{ equalTo: "" }`** → Text tab enabled, preserved on view + save
- **Text-tab authoring** (real edit) → still produces `[{equalTo: "…"}]`
- `pnpm run build`, `eslint packages/frontend/src`, `prettier --check` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
