### PR TITLE
feat: serve the standalone image under a sub-path via BASE_PATH

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,12 @@ docker run -d \
 
 Then register existing WireMock instances from the UI.
 
+**Sub-path deployment:** set `BASE_PATH` (e.g. `-e BASE_PATH=/hub`) to serve the UI and API
+under a sub-path like the All-in-One image. The frontend is built with a placeholder base path
+that `docker/apply-base-path.sh` renders at container start (or at build time in a derived image
+for read-only filesystems), and the backend strips the prefix via Fastify's `rewriteUrl`, so
+URLs work both with and without the prefix.
+
 ### Docker Compose
 
 ```bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,12 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 # Generate Prisma client first (required for TypeScript build)
 RUN cd packages/backend && pnpm exec prisma generate
 
-# Build all packages with version from tag
+# Build all packages with version from tag.
+# The frontend is built with a placeholder base path that is replaced at
+# container start (or image build) by docker/apply-base-path.sh, so the UI
+# can be served under a sub-path via the BASE_PATH env var without a rebuild.
 ENV VITE_APP_VERSION=${APP_VERSION}
+ENV VITE_BASE_PATH=/__WIREMOCK_HUB_BASE__/
 RUN pnpm run build
 
 # Production stage
@@ -74,6 +78,15 @@ COPY --from=builder /app/packages/frontend/dist ./packages/frontend/dist
 # Remove favicon.ico if exists (Vue default) - we use favicon.svg
 RUN rm -f ./packages/frontend/dist/favicon.ico
 
+# Base path support: keep a pristine copy of the frontend dist (with the
+# placeholder base path), then render the default root base path so the
+# image works out of the box without any filesystem writes at startup.
+# Set BASE_PATH (e.g. BASE_PATH=/hub) to serve the UI under a sub-path.
+COPY docker/apply-base-path.sh docker/entrypoint.sh /app/
+RUN chmod +x /app/apply-base-path.sh /app/entrypoint.sh && \
+    tar -czf /app/frontend-dist-template.tar.gz -C /app/packages/frontend dist && \
+    /app/apply-base-path.sh
+
 # Create data directories for SQLite (new path + old path for backward compatibility)
 RUN mkdir -p /data /app/packages/backend/data
 
@@ -90,17 +103,6 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/projects || exit 1
 
-# Start the application with database migration and initialization
+# Start the application with base path rendering, database migration and initialization
 WORKDIR /app/packages/backend
-CMD ["sh", "-c", "\
-  # Migrate from old path if exists (backward compatibility with v0.x) \n\
-  if [ -f /app/packages/backend/data/wiremock-hub.db ] && [ ! -f /data/wiremock-hub.db ]; then \
-    echo '[Migration] Copying database from old location...'; \
-    cp /app/packages/backend/data/wiremock-hub.db /data/wiremock-hub.db; \
-    echo '[Migration] Done. Update your volume mount to -v ./data:/data'; \
-  fi && \
-  # Initialize database if it doesn't exist \n\
-  if [ ! -f /data/wiremock-hub.db ]; then \
-    cat prisma/migrations/*/migration.sql | sqlite3 /data/wiremock-hub.db; \
-  fi && \
-  node dist/index.js"]
+CMD ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -113,6 +113,30 @@ open http://localhost:3000
 
 Then register your existing WireMock instances via the UI.
 
+#### Serving the standalone Hub under a sub-path
+
+Set the `BASE_PATH` environment variable to serve the UI and API under a
+sub-path — the same layout as the All-in-One image, useful behind a reverse
+proxy that routes e.g. `/hub/` to the Hub:
+
+```bash
+docker run -d -p 3000:3000 -e BASE_PATH=/hub ghcr.io/ykagano/wiremock-hub-standalone:latest
+open http://localhost:3000/hub/
+```
+
+Requests are served both with and without the prefix (`/hub/api/...` and
+`/api/...`), so prefix-stripping reverse proxies keep working. The frontend
+assets are re-rendered for the configured base path at container start; to
+bake the base path into a derived image instead (e.g. when running with a
+read-only root filesystem), set the env var and run the render script at
+build time:
+
+```dockerfile
+FROM ghcr.io/ykagano/wiremock-hub-standalone:latest
+ENV BASE_PATH=/hub
+RUN /app/apply-base-path.sh
+```
+
 ### Docker Compose Examples
 
 ```bash

--- a/allinone/Dockerfile
+++ b/allinone/Dockerfile
@@ -34,8 +34,10 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 # Build shared package first (frontend depends on it)
 RUN pnpm --filter @wiremock-hub/shared build
 
-# Build frontend with /hub base path and version from tag
-ENV VITE_BASE_PATH=/hub/
+# Build frontend with the placeholder base path (same build as the standalone
+# image); the /hub base path is baked in the runtime stage via
+# docker/apply-base-path.sh
+ENV VITE_BASE_PATH=/__WIREMOCK_HUB_BASE__/
 ENV VITE_APP_VERSION=${APP_VERSION}
 RUN pnpm run build:frontend
 
@@ -114,11 +116,21 @@ COPY --from=backend-builder /app/packages/shared/dist ./packages/shared/dist
 COPY --from=backend-builder /app/packages/backend/dist ./packages/backend/dist
 COPY --from=backend-builder /app/packages/backend/prisma ./packages/backend/prisma
 
-# Copy frontend build to backend's public directory
-COPY --from=frontend-builder /app/packages/frontend/dist ./packages/backend/public
+# Copy frontend build (served by the backend from packages/frontend/dist,
+# same layout as the standalone image)
+COPY --from=frontend-builder /app/packages/frontend/dist ./packages/frontend/dist
 
 # Remove favicon.ico if exists (Vue default) - we use favicon.svg
-RUN rm -f ./packages/backend/public/favicon.ico
+RUN rm -f ./packages/frontend/dist/favicon.ico
+
+# Bake the /hub base path into the frontend with the shared render script.
+# BASE_PATH stays set at runtime so the backend also strips the prefix.
+# Changing it requires a matching nginx.conf, so it is baked, not runtime-set.
+COPY docker/apply-base-path.sh /app/apply-base-path.sh
+ENV BASE_PATH=/hub
+RUN chmod +x /app/apply-base-path.sh && \
+    tar -czf /app/frontend-dist-template.tar.gz -C /app/packages/frontend dist && \
+    /app/apply-base-path.sh
 
 # Download WireMock standalone (version pinned for API stability)
 RUN wget -O /app/wiremock-standalone.jar \

--- a/allinone/README.md
+++ b/allinone/README.md
@@ -123,6 +123,19 @@ For ECS/Fargate, mount an EFS volume to `/data` (see task definition example abo
 | `WIREMOCK_OPTS` | `--global-response-templating` | Extra WireMock CLI options                                       |
 | `BASE_PATH`     | `/hub`                         | Hub base path (baked at image build; `nginx.conf` must match it) |
 
+## Changing the Base Path
+
+The image keeps the pristine frontend template (`/app/frontend-dist-template.tar.gz`),
+so a derived image can re-bake a different base path. Provide an `nginx.conf`
+whose Hub location matches the new path:
+
+```dockerfile
+FROM ghcr.io/ykagano/wiremock-hub:latest
+ENV BASE_PATH=/mock
+RUN /app/apply-base-path.sh
+COPY my-nginx.conf /etc/nginx/http.d/default.conf
+```
+
 ## Project Configuration
 
 ### WireMock URL Settings

--- a/allinone/README.md
+++ b/allinone/README.md
@@ -114,13 +114,14 @@ For ECS/Fargate, mount an EFS volume to `/data` (see task definition example abo
 
 ## Environment Variables
 
-| Variable        | Default Value                  | Description                |
-| --------------- | ------------------------------ | -------------------------- |
-| `NODE_ENV`      | `production`                   | Runtime environment        |
-| `DATABASE_URL`  | `file:/data/wiremock-hub.db`   | Database connection URL    |
-| `PORT`          | `3001`                         | Hub API port (internal)    |
-| `WIREMOCK_PORT` | `8080`                         | WireMock port (internal)   |
-| `WIREMOCK_OPTS` | `--global-response-templating` | Extra WireMock CLI options |
+| Variable        | Default Value                  | Description                                                      |
+| --------------- | ------------------------------ | ---------------------------------------------------------------- |
+| `NODE_ENV`      | `production`                   | Runtime environment                                              |
+| `DATABASE_URL`  | `file:/data/wiremock-hub.db`   | Database connection URL                                          |
+| `PORT`          | `3001`                         | Hub API port (internal)                                          |
+| `WIREMOCK_PORT` | `8080`                         | WireMock port (internal)                                         |
+| `WIREMOCK_OPTS` | `--global-response-templating` | Extra WireMock CLI options                                       |
+| `BASE_PATH`     | `/hub`                         | Hub base path (baked at image build; `nginx.conf` must match it) |
 
 ## Project Configuration
 

--- a/allinone/README.md
+++ b/allinone/README.md
@@ -187,13 +187,13 @@ docker exec -it wiremock-hub-allinone supervisorctl restart wiremock-hub
 
 ## Comparison with Standard Version
 
-| Feature              | Standard Version    | All-in-One Version |
-| -------------------- | ------------------- | ------------------ |
-| Number of Containers | 2+ (Hub + WireMock) | 1                  |
-| Number of Ports      | 2 (3000 + 8080)     | 1 (3000)           |
-| Distributed WireMock | Supported           | Not Supported      |
-| ECS Optimization     | -                   | Supported          |
-| Hub UI Path          | `/`                 | `/hub/`            |
+| Feature              | Standard Version                   | All-in-One Version |
+| -------------------- | ---------------------------------- | ------------------ |
+| Number of Containers | 2+ (Hub + WireMock)                | 1                  |
+| Number of Ports      | 2 (3000 + 8080)                    | 1 (3000)           |
+| Distributed WireMock | Supported                          | Not Supported      |
+| ECS Optimization     | -                                  | Supported          |
+| Hub UI Path          | `/` (configurable via `BASE_PATH`) | `/hub/`            |
 
 ## License
 

--- a/docker/apply-base-path.sh
+++ b/docker/apply-base-path.sh
@@ -23,7 +23,8 @@ PLACEHOLDER="/__WIREMOCK_HUB_BASE__"
 FRONTEND_DIR="/app/packages/frontend"
 DIST_DIR="$FRONTEND_DIR/dist"
 TEMPLATE="/app/frontend-dist-template.tar.gz"
-MARKER="$DIST_DIR/.base-path"
+# The marker lives outside dist/ so it is never served as a static file
+MARKER="$FRONTEND_DIR/.base-path"
 
 # When BASE_PATH is not set at all, keep whatever is currently rendered
 # (the root default, or a base path baked into a derived image at build time).
@@ -49,6 +50,7 @@ if [ -f "$MARKER" ] && [ "$(cat "$MARKER")" = "$BASE_PATH" ]; then
 fi
 
 echo "Rendering frontend for base path '${BASE_PATH:-/}'..."
+rm -f "$MARKER"
 rm -rf "$DIST_DIR"
 tar -xzf "$TEMPLATE" -C "$FRONTEND_DIR"
 find "$DIST_DIR" -type f \

--- a/docker/apply-base-path.sh
+++ b/docker/apply-base-path.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Render the frontend dist for the configured BASE_PATH.
+#
+# The standalone image builds the frontend with a placeholder base path
+# (/__WIREMOCK_HUB_BASE__/) baked into its assets, and keeps a pristine copy
+# of the dist as a tarball. This script extracts that copy and replaces the
+# placeholder with BASE_PATH ('' or '/' -> served at the root, '/hub' ->
+# served under /hub/).
+#
+# It is a no-op when the dist is already rendered for the requested
+# BASE_PATH (a marker file records the applied value), so the default
+# container start performs no filesystem writes.
+#
+# It can also be run at image build time to bake a base path into a derived
+# image (useful with read-only root filesystems). Keep the ENV so the backend
+# also strips the prefix at runtime:
+#   FROM ghcr.io/ykagano/wiremock-hub-standalone:latest
+#   ENV BASE_PATH=/hub
+#   RUN /app/apply-base-path.sh
+set -e
+
+PLACEHOLDER="/__WIREMOCK_HUB_BASE__"
+FRONTEND_DIR="/app/packages/frontend"
+DIST_DIR="$FRONTEND_DIR/dist"
+TEMPLATE="/app/frontend-dist-template.tar.gz"
+MARKER="$DIST_DIR/.base-path"
+
+# When BASE_PATH is not set at all, keep whatever is currently rendered
+# (the root default, or a base path baked into a derived image at build time).
+# The first render at image build time runs with BASE_PATH explicitly empty.
+if [ -z "${BASE_PATH+x}" ] && [ -f "$MARKER" ]; then
+  exit 0
+fi
+
+# Normalize to '' (root) or '/sub/path' without a trailing slash
+BASE_PATH="${BASE_PATH:-}"
+BASE_PATH=$(printf '%s' "$BASE_PATH" | sed 's|/*$||; s|^/*|/|; s|^/$||')
+
+# Reject characters that would break the sed replacement below
+case "$BASE_PATH" in
+  *[!A-Za-z0-9/_.-]*)
+    echo "ERROR: BASE_PATH may only contain letters, digits, '/', '_', '.' and '-' (got '$BASE_PATH')" >&2
+    exit 1
+    ;;
+esac
+
+if [ -f "$MARKER" ] && [ "$(cat "$MARKER")" = "$BASE_PATH" ]; then
+  exit 0
+fi
+
+echo "Rendering frontend for base path '${BASE_PATH:-/}'..."
+rm -rf "$DIST_DIR"
+tar -xzf "$TEMPLATE" -C "$FRONTEND_DIR"
+find "$DIST_DIR" -type f \
+  \( -name '*.js' -o -name '*.css' -o -name '*.html' -o -name '*.json' \
+  -o -name '*.svg' -o -name '*.map' -o -name '*.txt' -o -name '*.webmanifest' \) \
+  -exec sed -i "s|$PLACEHOLDER|$BASE_PATH|g" {} +
+printf '%s' "$BASE_PATH" > "$MARKER"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+# Render the frontend for the configured BASE_PATH (no-op when already rendered)
+/app/apply-base-path.sh
+
+cd /app/packages/backend
+
+# Migrate from old path if exists (backward compatibility with v0.x)
+if [ -f /app/packages/backend/data/wiremock-hub.db ] && [ ! -f /data/wiremock-hub.db ]; then
+  echo '[Migration] Copying database from old location...'
+  cp /app/packages/backend/data/wiremock-hub.db /data/wiremock-hub.db
+  echo '[Migration] Done. Update your volume mount to -v ./data:/data'
+fi
+
+# Initialize database if it doesn't exist
+if [ ! -f /data/wiremock-hub.db ]; then
+  cat prisma/migrations/*/migration.sql | sqlite3 /data/wiremock-hub.db
+fi
+
+exec node dist/index.js

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
-import Fastify, { FastifyInstance } from 'fastify';
+import Fastify, { FastifyInstance, FastifyServerOptions } from 'fastify';
 import cors from '@fastify/cors';
 import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3';
 import { PrismaClient } from './generated/prisma/client.js';
@@ -10,6 +10,7 @@ import { wiremockInstanceRoutes } from './routes/wiremock-instances.js';
 import { healthRoutes } from './routes/health.js';
 import { mcpRoutes } from './routes/mcp.js';
 import { getDatabaseUrl, migrateDatabase } from './utils/database.js';
+import { normalizeBasePath } from './utils/base-path.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -17,10 +18,16 @@ const __dirname = path.dirname(__filename);
 export interface BuildAppOptions {
   logger?: boolean;
   databaseUrl?: string;
+  basePath?: string;
 }
 
 export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyInstance> {
-  const { logger = false, databaseUrl } = options;
+  const { logger = false, databaseUrl, basePath } = options;
+
+  // Serve the app under a sub-path (e.g. BASE_PATH=/hub) by stripping the
+  // prefix before routing. URLs without the prefix keep working, so the app
+  // stays reachable both directly and behind a prefix-stripping reverse proxy.
+  const base = normalizeBasePath(basePath ?? process.env.BASE_PATH);
 
   // Migrate database from old location if needed (for existing users upgrading)
   // From dist/app.js -> 3 levels up to project root
@@ -32,7 +39,24 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   });
   const prisma = new PrismaClient({ adapter });
 
-  const fastify = Fastify({ logger });
+  const serverOptions: FastifyServerOptions = { logger };
+  if (base) {
+    serverOptions.rewriteUrl = (req) => {
+      const url = req.url ?? '/';
+      if (url === base) {
+        return '/';
+      }
+      if (url.startsWith(`${base}/`)) {
+        return url.slice(base.length);
+      }
+      if (url.startsWith(`${base}?`)) {
+        return `/${url.slice(base.length)}`;
+      }
+      return url;
+    };
+  }
+
+  const fastify = Fastify(serverOptions);
 
   // Register plugins
   await fastify.register(cors, {

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -2,7 +2,6 @@ import 'dotenv/config';
 import fastifyStatic from '@fastify/static';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { existsSync } from 'fs';
 import { buildApp } from './app.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -12,12 +11,9 @@ const fastify = await buildApp({ logger: true });
 
 // Serve frontend static files in production
 if (process.env.NODE_ENV === 'production') {
-  // __dirname is /app/packages/backend/dist
-  // Check for public directory first (Docker), then fall back to frontend/dist (local)
-  const publicPath = path.join(__dirname, '../public');
-  const frontendPath = path.join(__dirname, '../../frontend/dist');
-
-  const staticPath = existsSync(publicPath) ? publicPath : frontendPath;
+  // __dirname is /app/packages/backend/dist; both Docker images and local
+  // production runs serve the frontend from packages/frontend/dist
+  const staticPath = path.join(__dirname, '../../frontend/dist');
 
   await fastify.register(fastifyStatic, {
     root: staticPath,

--- a/packages/backend/src/utils/base-path.ts
+++ b/packages/backend/src/utils/base-path.ts
@@ -1,0 +1,16 @@
+/**
+ * Normalize a base path for URL prefix matching.
+ *
+ * Returns '' when no base path is configured (empty, '/', or whitespace),
+ * otherwise a path with a leading slash and no trailing slash
+ * (e.g. 'hub/', '/hub', '/hub/' all normalize to '/hub').
+ */
+export function normalizeBasePath(input?: string | null): string {
+  const trimmed = (input ?? '').trim();
+  if (trimmed === '') {
+    return '';
+  }
+  const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  const withoutTrailingSlashes = withLeadingSlash.replace(/\/+$/, '');
+  return withoutTrailingSlashes === '' ? '' : withoutTrailingSlashes;
+}

--- a/packages/backend/tests/routes/base-path.test.ts
+++ b/packages/backend/tests/routes/base-path.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { FastifyInstance } from 'fastify';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { buildApp } from '../../src/app.js';
+import { resetAndCreateProject } from '../helpers.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Same test database as tests/setup.ts (already migrated by the global setup)
+const TEST_DB_URL = `file:${path.join(__dirname, '../../data-test/test.db')}`;
+
+describe('base path support (BASE_PATH)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = await buildApp({
+      logger: false,
+      databaseUrl: TEST_DB_URL,
+      basePath: '/hub'
+    });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('serves API routes under the base path', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/hub/api/health'
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ status: 'ok' });
+  });
+
+  it('still serves API routes without the base path prefix', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/health'
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ status: 'ok' });
+  });
+
+  it('rewrites the bare base path to the root', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/hub'
+    });
+
+    // No static files are registered in tests, so the root route is a 404,
+    // but the URL must have been rewritten to '/' (not treated as unknown '/hub')
+    expect(response.statusCode).toBe(404);
+    const message = response.json().message as string;
+    expect(message).toContain('GET:/');
+    expect(message).not.toContain('/hub');
+  });
+
+  it('preserves query strings when stripping the base path', async () => {
+    const projectId = await resetAndCreateProject('Base Path Test Project');
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/hub/api/stubs?projectId=${projectId}`
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ success: true, data: [] });
+  });
+
+  it('does not strip paths that only share the base path as a prefix substring', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/hubx/api/health'
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('normalizes the configured base path before matching', async () => {
+    const normalizedApp = await buildApp({
+      logger: false,
+      databaseUrl: TEST_DB_URL,
+      basePath: 'hub/'
+    });
+    await normalizedApp.ready();
+
+    try {
+      const response = await normalizedApp.inject({
+        method: 'GET',
+        url: '/hub/api/health'
+      });
+
+      expect(response.statusCode).toBe(200);
+    } finally {
+      await normalizedApp.close();
+    }
+  });
+});

--- a/packages/backend/tests/utils/base-path.test.ts
+++ b/packages/backend/tests/utils/base-path.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeBasePath } from '../../src/utils/base-path.js';
+
+describe('normalizeBasePath', () => {
+  it('returns empty string when no base path is configured', () => {
+    expect(normalizeBasePath(undefined)).toBe('');
+    expect(normalizeBasePath(null)).toBe('');
+    expect(normalizeBasePath('')).toBe('');
+    expect(normalizeBasePath('   ')).toBe('');
+    expect(normalizeBasePath('/')).toBe('');
+    expect(normalizeBasePath('///')).toBe('');
+  });
+
+  it('adds a leading slash when missing', () => {
+    expect(normalizeBasePath('hub')).toBe('/hub');
+    expect(normalizeBasePath('hub/nested')).toBe('/hub/nested');
+  });
+
+  it('removes trailing slashes', () => {
+    expect(normalizeBasePath('/hub/')).toBe('/hub');
+    expect(normalizeBasePath('/hub///')).toBe('/hub');
+    expect(normalizeBasePath('hub/')).toBe('/hub');
+  });
+
+  it('keeps already normalized paths as-is', () => {
+    expect(normalizeBasePath('/hub')).toBe('/hub');
+    expect(normalizeBasePath('/hub/nested')).toBe('/hub/nested');
+  });
+});


### PR DESCRIPTION
## Summary

Allow the standalone Docker image to serve the Hub under a sub-path (e.g. `/hub/`) via a `BASE_PATH` environment variable, without rebuilding the frontend — and unify the All-in-One image onto the same mechanism, so both images share an identical frontend build. Default (root path) behavior of the standalone image is unchanged.

## Reason for Change

The standalone image bakes the frontend base path (`/`) into its build artifacts: `index.html` references `/assets/...` absolutely, and the minified bundle embeds the Vue Router history base and the API base URL (`"/api"`) as string literals. A reverse proxy therefore cannot relocate the UI to `/hub/` the way the All-in-One image does — assets 404, the router matches nothing at `/hub/`, and API calls escape the prefix. Until now the only way to serve the standalone Hub under a sub-path was to rebuild the frontend from source with `VITE_BASE_PATH`, which is also why the All-in-One image maintained its own dedicated `/hub/` frontend build.

## Changes

### Docker (standalone)

- The frontend is built with a placeholder base path (`/__WIREMOCK_HUB_BASE__/`), and a pristine copy of the dist is kept in the image as a tarball
- New `docker/apply-base-path.sh` renders the dist for the configured `BASE_PATH` by replacing the placeholder in text assets, guarded by a marker file so re-renders only happen when the value changes
  - The root default is rendered at image build time, so a default container start performs **no filesystem writes** (read-only root filesystems keep working, behavior identical to today)
  - `-e BASE_PATH=/hub` re-renders once at container start
  - Derived images can bake the base path at build time (`ENV BASE_PATH=/hub` + `RUN /app/apply-base-path.sh`) for read-only-rootfs deployments
- The inline `CMD` shell script moved to `docker/entrypoint.sh`, which runs the render step before the existing DB migration/initialization logic (unchanged)

### Docker (All-in-One)

- The dedicated `VITE_BASE_PATH=/hub/` frontend build is gone: the frontend is built with the same placeholder as the standalone image, and `/hub` is baked in the runtime stage via the shared `docker/apply-base-path.sh`
- The frontend now lands in `packages/frontend/dist` (same layout as the standalone image) instead of a special-cased `packages/backend/public` copy
- `BASE_PATH=/hub` stays set at runtime so the backend also strips the prefix; it is baked rather than runtime-configurable because `nginx.conf` routing must match it

### Backend

- `buildApp` accepts a `basePath` option (defaulting to the `BASE_PATH` env var) and strips the prefix via Fastify's `rewriteUrl`, so routes work both with and without the prefix — direct access and prefix-stripping reverse proxies are both supported
- New `normalizeBasePath` util (`''` for root, otherwise leading slash / no trailing slash)

### Tests

- `tests/utils/base-path.test.ts`: normalization cases
- `tests/routes/base-path.test.ts`: prefixed and unprefixed routing, bare base path rewrite, query-string preservation, no false-prefix matches (`/hubx/...`), and input normalization

### Docs

- README: standalone sub-path usage (env var and derived-image patterns)
- All-in-One README: `BASE_PATH` env var row; CLAUDE.md and the comparison table updated

## Verification

- `pnpm test` (backend): 261 passed
- Standalone image exercised in three modes: default (root, no startup writes), `-e BASE_PATH=/hub`, and a derived image with the base path baked, running with `--read-only` — UI, assets, SPA deep links, and `/hub/api/*` all verified
- All-in-One image rebuilt on the shared mechanism and verified: `/hub/` UI + assets, `/hub/api/health`, `/__admin/health`, mock responses at `/`, and the `/hub` → `/hub/` redirect
